### PR TITLE
travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+ - "2.7"
+# command to install dependencies
+before_install:
+  - pip install cython jsonschema ipython
+  - pip install -e git+https://github.com/opencobra/cobrapy.git\#egg=cobra
+install:
+  - python setup.py develop
+# # command to run tests
+script: python setup.py test --noweb --pyonly
+notifications:
+  email: false

--- a/escher/convert_map.py
+++ b/escher/convert_map.py
@@ -16,13 +16,20 @@ python convert_map.py another_old_map.json output_directory path/to/iJO1366.sbml
 
 """
 
+try:
+    import cobra.io
+    import jsonschema
+except ImportError:
+    raise Exception(('The Python packages jsonschema and COBRApy (0.3.0b3 or later) '
+                     'are required for converting maps.'))
+try:
+    from theseus import load_model
+except ImportError:
+    print 'Theseus not available (https://github.com/zakandrewking/Theseus)'
 import sys
-import cobra.io
 import json
-from theseus import load_model
 from os.path import basename, join
 from urllib2 import urlopen
-import jsonschema
 import re
 
 from escher.validate import get_jsonschema, check_segments

--- a/escher/plots.py
+++ b/escher/plots.py
@@ -576,7 +576,10 @@ class Builder(object):
         if menu=='all':
             raise Exception("The 'all' menu option cannot be used in an IPython notebook.")
         # import here, in case users don't have requirements installed
-        from IPython.display import HTML
+        try:
+            from IPython.display import HTML
+        except ImportError:
+            raise Exception('You need to be using the IPython notebook for this function to work')
         return HTML(html)
 
     

--- a/escher/tests/test_server.py
+++ b/escher/tests/test_server.py
@@ -16,15 +16,13 @@ class TestBuilder(AsyncHTTPTestCase):
         
         response = self.fetch('/builder.html')
         assert response.code==200
-        response = self.fetch('/web/builder.html')
-        assert response.code==200
         
     def test_dev_builder_request(self):
         # set the correct port
         escher.server.PORT = self.get_http_port()
         print escher.server.PORT
 
-        response = self.fetch('/dev/builder.html')
+        response = self.fetch('/builder.html?js_source=dev')
         assert response.code==200
         
     def test_local_builder_request(self):
@@ -32,7 +30,7 @@ class TestBuilder(AsyncHTTPTestCase):
         escher.server.PORT = self.get_http_port()
         print escher.server.PORT
 
-        response = self.fetch('/local/builder.html')
+        response = self.fetch('/builder.html?js_source=local')
         assert response.code==200
         
 def test_server():

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from shutil import copy, move
 from os.path import join, dirname, realpath, exists
 from glob import glob
 import re
-    
+
 try:
     from setuptools import setup, Command
 except:
@@ -147,13 +147,17 @@ class TestCommand(Command):
         pass
     def run(self):
         if not self.jsonly:
+            import pytest
             if self.noweb:
-                call('py.test -m "not web"', shell=True)
+                exit_code = pytest.main(['-m', 'not web'])
             else:
-                call('py.test', shell=True)
+                exit_code = pytest.main()
+        else:
+            exit_code = 0
         if not self.pyonly:
             call(['jasmine', '--port=%d' % port])
-        
+        sys.exit(exit_code)
+
 setup(name='Escher',
       version=version,
       author='Zachary King',


### PR DESCRIPTION
Run Travis CI tests for the Python package. To enable Travis CI, a few changes to setup.py were necessary.
