### PR TITLE
Export as PNG

### DIFF
--- a/js/src/Builder.js
+++ b/js/src/Builder.js
@@ -685,6 +685,9 @@ function _set_up_menu(menu_selection, map, key_manager, keys, enable_editing,
         .button({ key: keys.save_svg,
                   text: 'Export as SVG',
                   key_text: (enable_keys ? ' (Ctrl+Shift+S)' : null) })
+        .button({ key: keys.save_png,
+                  text: 'Export as PNG',
+                  key_text: (enable_keys ? ' (Ctrl+Shift+P)' : null) })
         .button({ key: keys.clear_map,
                   text: 'Clear map' })
     // model dropdown
@@ -1178,6 +1181,11 @@ function _get_keys(map, zoom_container, search_bar, settings_bar, enable_editing
             key: 'ctrl+shift+s',
             target: map,
             fn: map.save_svg
+        },
+        save_png: {
+            key: 'ctrl+shift+p',
+            target: map,
+            fn: map.save_png
         },
         load: {
             key: 'ctrl+o',

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -2137,94 +2137,64 @@ function map_for_export() {
     return out;
 }
 
-function save_svg() {
-    /** Rescale the canvas and save svg.
+function save_map(obj, callback_before, callback_after, map_type) {
+    /** Rescale the canvas and save as svg/png.
 
      */
+
     // run the before callback
-    this.callback_manager.run('before_svg_export');
+    obj.callback_manager.run(callback_before);
 
-    // turn of zoom and translate so that illustrator likes the map
-    var window_scale = this.zoom_container.window_scale,
-        window_translate = this.zoom_container.window_translate,
-        canvas_size_and_loc = this.canvas.size_and_location(),
+    // turn ofo zoom and translate so that illustrator likes the map
+    var window_scale = obj.zoom_container.window_scale,
+        window_translate = obj.zoom_container.window_translate,
+        canvas_size_and_loc = obj.canvas.size_and_location(),
         mouse_node_size_and_trans = {
-            w: this.canvas.mouse_node.attr('width'),
-            h: this.canvas.mouse_node.attr('height'),
-            transform: this.canvas.mouse_node.attr('transform')
+            w: obj.canvas.mouse_node.attr('width'),
+            h: obj.canvas.mouse_node.attr('height'),
+            transform: obj.canvas.mouse_node.attr('transform')
         };
-    this.zoom_container._go_to_svg(1.0, { x: -canvas_size_and_loc.x, y: -canvas_size_and_loc.y }, function() {
-        this.svg.attr('width', canvas_size_and_loc.width);
-        this.svg.attr('height', canvas_size_and_loc.height);
-        this.canvas.mouse_node.attr('width', '0px');
-        this.canvas.mouse_node.attr('height', '0px');
-        this.canvas.mouse_node.attr('transform', null);
+
+    obj.zoom_container._go_to_svg(1.0, { x: -canvas_size_and_loc.x, y: -canvas_size_and_loc.y }, function() {
+        obj.svg.attr('width', canvas_size_and_loc.width);
+        obj.svg.attr('height', canvas_size_and_loc.height);
+        obj.canvas.mouse_node.attr('width', '0px');
+        obj.canvas.mouse_node.attr('height', '0px');
+        obj.canvas.mouse_node.attr('transform', null);
+
         // hide the segment control points
-        var hidden_sel = this.sel.selectAll('.multimarker-circle,.midmarker-circle,#canvas')
-                .style('visibility', 'hidden');
-
-        // do the epxort
-        utils.download_svg('saved_map', this.svg, true);
-
-        // revert everything
-        this.zoom_container._go_to_svg(window_scale, window_translate, function() {
-            this.svg.attr('width', null);
-            this.svg.attr('height', null);
-            this.canvas.mouse_node.attr('width', mouse_node_size_and_trans.w);
-            this.canvas.mouse_node.attr('height', mouse_node_size_and_trans.h);
-            this.canvas.mouse_node.attr('transform', mouse_node_size_and_trans.transform);
-            // unhide the segment control points
-            hidden_sel.style('visibility', null);
-
-            // run the after callback
-            this.callback_manager.run('after_svg_export');
-        }.bind(this));
-    }.bind(this));
-}
-
-function save_png() {
-    /** Rescale the canvas and save png image.
-
-     */
-    // run the before callback
-    this.callback_manager.run('before_png_export');
-
-    // turn of zoom and translate so that illustrator likes the map
-    var window_scale = this.zoom_container.window_scale,
-        window_translate = this.zoom_container.window_translate,
-        canvas_size_and_loc = this.canvas.size_and_location(),
-        mouse_node_size_and_trans = {
-            w: this.canvas.mouse_node.attr('width'),
-            h: this.canvas.mouse_node.attr('height'),
-            transform: this.canvas.mouse_node.attr('transform')
-        };
-    this.zoom_container._go_to_svg(1.0, { x: -canvas_size_and_loc.x, y: -canvas_size_and_loc.y }, function() {
-        this.svg.attr('width', canvas_size_and_loc.width);
-        this.svg.attr('height', canvas_size_and_loc.height);
-        this.canvas.mouse_node.attr('width', '0px');
-        this.canvas.mouse_node.attr('height', '0px');
-        this.canvas.mouse_node.attr('transform', null);
-        // hide the segment control points
-        var hidden_sel = this.sel.selectAll('.multimarker-circle,.midmarker-circle,#canvas')
+        var hidden_sel = obj.sel.selectAll('.multimarker-circle,.midmarker-circle,#canvas')
             .style('visibility', 'hidden');
 
         // do the export
-        utils.download_png('saved_map', this.svg, true);
+        if(map_type == 'svg') {
+            utils.download_svg('saved_map', obj.svg, true);
+        } else if(map_type == 'png') {
+            utils.download_png('saved_map', obj.svg, true);
+        }
 
         // revert everything
-        this.zoom_container._go_to_svg(window_scale, window_translate, function() {
-            this.svg.attr('width', null);
-            this.svg.attr('height', null);
-            this.canvas.mouse_node.attr('width', mouse_node_size_and_trans.w);
-            this.canvas.mouse_node.attr('height', mouse_node_size_and_trans.h);
-            this.canvas.mouse_node.attr('transform', mouse_node_size_and_trans.transform);
+        obj.zoom_container._go_to_svg(window_scale, window_translate, function() {
+            obj.svg.attr('width', null);
+            obj.svg.attr('height', null);
+            obj.canvas.mouse_node.attr('width', mouse_node_size_and_trans.w);
+            obj.canvas.mouse_node.attr('height', mouse_node_size_and_trans.h);
+            obj.canvas.mouse_node.attr('transform', mouse_node_size_and_trans.transform);
             // unhide the segment control points
             hidden_sel.style('visibility', null);
 
             // run the after callback
-            this.callback_manager.run('after_png_export');
-        }.bind(this));
-    }.bind(this));
+            obj.callback_manager.run(callback_after);
+        }.bind(obj));
+    }.bind(obj));
+}
+
+function save_svg() {
+    save_map(this, 'before_svg_export', 'after_svg_export', 'svg');
+}
+
+function save_png() {
+    save_map(this, 'before_png_export', 'after_png_export', 'png');
 }
 
 function convert_map() {

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -744,24 +744,39 @@ function download_png(name, svg_sel, do_beautify) {
      *
      */
 
-    // alert if blob isn't going to work
+    // Alert if blob isn't going to work
     _check_filesaver();
 
-    // make the xml string
+    // Make the xml string
     var xml = (new XMLSerializer()).serializeToString(svg_sel.node());
-    /*if (do_beautify) xml = vkbeautify.xml(xml);
+    if (do_beautify) xml = vkbeautify.xml(xml);
     xml = ('<?xml version="1.0" encoding="utf-8"?>\n' +
-    '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"\n' +
-    ' "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' +
-    xml);*/
+           '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"\n' +
+           ' "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' +
+           xml);
 
-    var pngBase64 = window.btoa(xml);
+    // Canvas to hold the image
+    var canvas = document.createElement('canvas');
+    var context = canvas.getContext('2d');
 
-    console.log(pngBase64);
+    // Canvas size = SVG size
+    var svg_size = svg_sel.node().getBBox();
+    canvas.width = svg_size.width;
+    canvas.height = svg_size.height;
 
-    // save
-    var blob = new Blob([pngBase64], { type: 'data:image/png;base64' });
-    saveAs(blob, name + '.png');
+    // Image element appended with data
+    var base_image = new Image();
+    base_image.src = 'data:image/svg+xml;base64,' + btoa(xml);
+
+    base_image.onload = function() {
+        // Draw image to canvas
+        context.drawImage(base_image, 0, 0);
+
+        // Save image
+        canvas.toBlob(function(blob) {
+            saveAs(blob, name + ".png");
+        });
+    };
 };
 
 function rotate_coords_recursive(coords_array, angle, center) {

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -731,7 +731,7 @@ function download_svg(name, svg_sel, do_beautify) {
 };
 
 function download_png(name, svg_sel, do_beautify) {
-    /** Download an png file using FileSaver.js.
+    /** Download a png file using FileSaver.js.
      *
      * Arguments
      * ---------
@@ -759,10 +759,24 @@ function download_png(name, svg_sel, do_beautify) {
     var canvas = document.createElement('canvas');
     var context = canvas.getContext('2d');
 
-    // Canvas size = SVG size
+    // Get SVG size
     var svg_size = svg_sel.node().getBBox();
-    canvas.width = svg_size.width;
-    canvas.height = svg_size.height;
+    var svg_width = svg_size.width + svg_size.x;
+    var svg_height = svg_size.height + svg_size.y;
+
+    // Canvas size = SVG size. Constrained to 10000px for very large SVGs
+    if (svg_width < 10000 && svg_height < 10000) {
+        canvas.width = svg_width;
+        canvas.height = svg_height;
+    } else {
+        if (canvas.width > canvas.height) {
+            canvas.width = 10000;
+            canvas.height = 10000*(svg_height/svg_width);
+        } else {
+            canvas.width = 10000*(svg_width/svg_height);
+            canvas.height = 10000;
+        }
+    }
 
     // Image element appended with data
     var base_image = new Image();
@@ -770,7 +784,7 @@ function download_png(name, svg_sel, do_beautify) {
 
     base_image.onload = function() {
         // Draw image to canvas
-        context.drawImage(base_image, 0, 0);
+        context.drawImage(base_image, 0, 0, canvas.width, canvas.height);
 
         // Save image
         canvas.toBlob(function(blob) {

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -37,6 +37,7 @@ module.exports = {
     load_json: load_json,
     load_json_or_csv: load_json_or_csv,
     download_svg: download_svg,
+    download_png: download_png,
     rotate_coords_recursive: rotate_coords_recursive,
     rotate_coords: rotate_coords,
     get_angle: get_angle,
@@ -727,6 +728,40 @@ function download_svg(name, svg_sel, do_beautify) {
     // save
     var blob = new Blob([xml], { type: 'image/svg+xml' });
     saveAs(blob, name + '.svg');
+};
+
+function download_png(name, svg_sel, do_beautify) {
+    /** Download an png file using FileSaver.js.
+     *
+     * Arguments
+     * ---------
+     *
+     * name: The filename (without extension).
+     *
+     * svg_sel: The d3 selection for the SVG element.
+     *
+     * do_beautify: (Boolean) If true, then beautify the SVG output.
+     *
+     */
+
+    // alert if blob isn't going to work
+    _check_filesaver();
+
+    // make the xml string
+    var xml = (new XMLSerializer()).serializeToString(svg_sel.node());
+    /*if (do_beautify) xml = vkbeautify.xml(xml);
+    xml = ('<?xml version="1.0" encoding="utf-8"?>\n' +
+    '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"\n' +
+    ' "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' +
+    xml);*/
+
+    var pngBase64 = window.btoa(xml);
+
+    console.log(pngBase64);
+
+    // save
+    var blob = new Blob([pngBase64], { type: 'data:image/png;base64' });
+    saveAs(blob, name + '.png');
 };
 
 function rotate_coords_recursive(coords_array, angle, center) {

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -783,7 +783,9 @@ function download_png(name, svg_sel, do_beautify) {
     base_image.src = 'data:image/svg+xml;base64,' + btoa(xml);
 
     base_image.onload = function() {
-        // Draw image to canvas
+        // Draw image to canvas with white background
+        context.fillStyle="#FFF";
+        context.fillRect( 0, 0, canvas.width, canvas.height);
         context.drawImage(base_image, 0, 0, canvas.width, canvas.height);
 
         // Save image


### PR DESCRIPTION
**Fixes  #155**
Exports SVG to PNG with its actual dimensions (for very large SVGs, sets constraint of 10000px to the width and height).

Issues:
- Filesaver.js _toBlob()_ is not supported by Safari and IE.