### PR TITLE
Add transpiler + linter to build flow

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ var package = require('./package.json')
 
 module.exports = function (grunt) {
   // common tasks
-  var tasks = [ 'cssmin', 'concat', 'browserify', 'extract_sourcemap', 'uglify',
+  var tasks = [ 'cssmin', 'concat', 'standard', 'browserify', 'extract_sourcemap', 'uglify',
                 'copy', ]
 
   // Project configuration
@@ -37,6 +37,17 @@ module.exports = function (grunt) {
       },
     },
     // js
+    standard: {
+      options: {
+        fix: true,
+        ignore: ['js/src/complete.ly.js']
+      },
+      app: {
+        src: [
+          'js/src/**.*.js'
+        ]
+      }
+    },
     browserify: {
       options: {
         transform: [
@@ -221,6 +232,8 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-istanbul')
   grunt.loadNpmTasks('grunt-env')
   grunt.loadNpmTasks('grunt-coveralls')
+  //style
+  grunt.loadNpmTasks('grunt-standard')
   // release
   grunt.loadNpmTasks('grunt-git');
   grunt.loadNpmTasks('grunt-release')

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,9 @@ module.exports = function (grunt) {
     // js
     browserify: {
       options: {
+        transform: [
+          ['babelify', { presets: ['es2015'] }]
+        ],
         browserifyOptions: {
           standalone: 'escher',
           debug: true,

--- a/js/src/Brush.js
+++ b/js/src/Brush.js
@@ -112,7 +112,7 @@ function setup_selection_brush () {
               selectable_selection.selectAll('.node:not(.selected),.text-label:not(.selected)') :
               selectable_selection.selectAll('.node,.text-label')
           )
-          selection.classed('selected', function (d) {
+          selection.classed('selected', (d) => {
             var sx = d.x
             var sy = d.y
             return (rect[0][0] <= sx && sx < rect[1][0] &&

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "node": ">=5.0"
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.24.1",
+    "babelify": "^7.3.0",
     "biojs-sniper": "^0.2.9",
     "bootstrap": "^3.3.6",
     "bootswatch": "^3.3.6",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "grunt-mocha-test": "^0.12.7",
     "grunt-release": "^0.13.0",
     "grunt-shell": "^1.1.2",
+    "grunt-standard": "^3.1.0",
     "jquery": "^2.2.0",
     "jsdom": "^7.2.2",
     "mocha": "^2.3.4"


### PR DESCRIPTION
- Added `babelify` to transpile ES6 to ES5
- Added `grunt-standard` to automagically lint the project