### PR TITLE
ES6 class for Builder with fallback for optional new

### DIFF
--- a/dev-server/index.js
+++ b/dev-server/index.js
@@ -1,7 +1,13 @@
 import map from '../docs/_static/example_data/S5_iJO1366.Glycolysis_PPP_AA_Nucleotides.json'
 import { Builder, libs } from '../src/main'
 
-Builder(map, null, null, libs.d3_select('#root'), {
-  fill_screen: true,
-  never_ask_before_quit: true
-})
+new Builder( // eslint-disable-line no-new
+  map,
+  null,
+  null,
+  libs.d3_select('#root'),
+  {
+    fill_screen: true,
+    never_ask_before_quit: true
+  }
+)

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -4,11 +4,29 @@
 
 /** @jsx h */
 import preact, { h } from 'preact'
-import ReactWrapper from './ReactWrapper.js'
-import BuilderSettingsMenu from './BuilderSettingsMenu.js'
-import ButtonPanel from './ButtonPanel.js'
-import BuilderMenuBar from './BuilderMenuBar.js'
+import ReactWrapper from './ReactWrapper'
+import BuilderSettingsMenu from './BuilderSettingsMenu'
+import ButtonPanel from './ButtonPanel'
+import BuilderMenuBar from './BuilderMenuBar'
 import SearchBar from './SearchBar.js'
+import * as utils from './utils'
+import BuildInput from './BuildInput'
+import ZoomContainer from './ZoomContainer'
+import Map from './Map'
+import CobraModel from './CobraModel'
+import Brush from './Brush'
+import CallbackManager from './CallbackManager'
+import ui from './ui'
+import Settings from './Settings'
+import TextEditInput from './TextEditInput'
+import QuickJump from './QuickJump'
+import data_styles from './data_styles'
+import TooltipContainer from './TooltipContainer'
+import DefaultTooltip from './DefaultTooltip'
+import _ from 'underscore'
+import { select as d3_select } from 'd3-selection'
+import { selection as d3_selection } from 'd3-selection'
+import { json as d3_json } from 'd3-request'
 
 // Include custom font set for icons
 import '../icons/css/fontello.css'
@@ -20,1221 +38,1176 @@ import './Builder.css'
 // uploaded to NPM.
 import builder_embed from '!!raw-loader!./Builder-embed.css'
 
-var utils = require('./utils')
-var BuildInput = require('./BuildInput')
-var ZoomContainer = require('./ZoomContainer')
-var Map = require('./Map')
-var CobraModel = require('./CobraModel')
-var Brush = require('./Brush')
-var CallbackManager = require('./CallbackManager')
-var Settings = require('./Settings')
-var TextEditInput = require('./TextEditInput')
-var QuickJump = require('./QuickJump')
-var data_styles = require('./data_styles')
-var TooltipContainer = require('./TooltipContainer')
-var DefaultTooltip = require('./DefaultTooltip').default
-var _ = require('underscore')
-var d3_select = require('d3-selection').select
-var d3_selection = require('d3-selection').selection
-var d3_json = require('d3-request').json
+class Builder {
+  constructor (map_data, model_data, embedded_css, selection, options) {
+    // Defaults
+    if (!selection) {
+      selection = d3_select('body').append('div')
+    } else if (selection instanceof d3_selection) {
+      // D3 V4 selection
+    } else if ('node' in selection) {
+      // If user passes in a selection from an different d3 version/instance,
+      // then reselect.
+      selection = d3_select(selection.node())
+    } else {
+      // HTML Element
+      selection = d3_select(selection)
+    }
+    if (!options) {
+      options = {}
+    }
+    if (!embedded_css) {
+      embedded_css = builder_embed
+    }
 
-var Builder = utils.make_class()
-Builder.prototype = {
-  init: init,
-  load_map: load_map,
-  load_model: load_model,
-  _set_mode: _set_mode,
-  pass_tooltip_component_props: pass_tooltip_component_props,
-  pass_settings_menu_props: pass_settings_menu_props,
-  view_mode: view_mode,
-  build_mode: build_mode,
-  brush_mode: brush_mode,
-  zoom_mode: zoom_mode,
-  rotate_mode: rotate_mode,
-  text_mode: text_mode,
-  _reaction_check_add_abs: _reaction_check_add_abs,
-  set_reaction_data: set_reaction_data,
-  set_metabolite_data: set_metabolite_data,
-  set_gene_data: set_gene_data,
-  _update_data: _update_data,
-  _create_status: _create_status,
-  _setup_status: _setup_status,
-  _setup_quick_jump: _setup_quick_jump,
-  _setup_modes: _setup_modes,
-  _get_keys: _get_keys,
-  _setup_confirm_before_exit: _setup_confirm_before_exit,
-  renderMenu: renderMenu,
-  renderSearchBar: renderSearchBar,
-  renderButtonPanel: renderButtonPanel
-}
-module.exports = Builder
+    this.map_data = map_data
+    this.model_data = model_data
+    this.embedded_css = embedded_css
+    this.selection = selection
+    this.menu_div = null
+    this.button_div = null
+    this.settings_div = null
+    this.settingsMenuRef = null
+    this.search_bar_div = null
+    this.searchBarRef = null
 
-function init (map_data, model_data, embedded_css, selection, options) {
-  // Defaults
-  if (!selection) {
-    selection = d3_select('body').append('div')
-  } else if (selection instanceof d3_selection) {
-    // D3 V4 selection
-  } else if ('node' in selection) {
-    // If user passes in a selection from an different d3 version/instance,
-    // then reselect.
-    selection = d3_select(selection.node())
-  } else {
-    // HTML Element
-    selection = d3_select(selection)
-  }
-  if (!options) {
-    options = {}
-  }
-  if (!embedded_css) {
-    embedded_css = builder_embed
-  }
+    // apply this object as data for the selection
+    this.selection.datum(this)
+    this.selection.__builder__ = this
 
-  this.map_data = map_data
-  this.model_data = model_data
-  this.embedded_css = embedded_css
-  this.selection = selection
-  this.menu_div = null
-  this.button_div = null
-  this.settings_div = null
-  this.settingsMenuRef = null
-  this.search_bar_div = null
-  this.searchBarRef = null
+    // Remember if the user provided a custom value for reaction_styles
+    this.has_custom_reaction_styles = Boolean(options.reaction_styles)
 
-  // apply this object as data for the selection
-  this.selection.datum(this)
-  this.selection.__builder__ = this
+    // set defaults
+    this.options = utils.set_options(options, {
+      // view options
+      menu: 'all',
+      scroll_behavior: 'pan',
+      use_3d_transform: !utils.check_browser('safari'),
+      enable_editing: true,
+      enable_keys: true,
+      enable_search: true,
+      fill_screen: false,
+      zoom_to_element: null,
+      full_screen_button: false,
+      ignore_bootstrap: false,
+      disabled_buttons: null,
+      // map, model, and styles
+      starting_reaction: null,
+      never_ask_before_quit: false,
+      unique_map_id: null,
+      primary_metabolite_radius: 20,
+      secondary_metabolite_radius: 10,
+      marker_radius: 5,
+      gene_font_size: 18,
+      hide_secondary_metabolites: false,
+      show_gene_reaction_rules: false,
+      hide_all_labels: false,
+      canvas_size_and_loc: null,
+      // applied data
+      // reaction
+      reaction_data: null,
+      reaction_styles: ['color', 'size', 'text'],
+      reaction_compare_style: 'log2_fold',
+      reaction_scale: [ { type: 'min', color: '#c8c8c8', size: 12 },
+                        { type: 'median', color: '#9696ff', size: 20 },
+                        { type: 'max', color: '#ff0000', size: 25 } ],
+      reaction_no_data_color: '#dcdcdc',
+      reaction_no_data_size: 8,
+      // gene
+      gene_data: null,
+      and_method_in_gene_reaction_rule: 'mean',
+      // metabolite
+      metabolite_data: null,
+      metabolite_styles: ['color', 'size', 'text'],
+      metabolite_compare_style: 'log2_fold',
+      metabolite_scale: [ { type: 'min', color: '#fffaf0', size: 20 },
+                          { type: 'median', color: '#f1c470', size: 30 },
+                          { type: 'max', color: '#800000', size: 40 } ],
+      metabolite_no_data_color: '#ffffff',
+      metabolite_no_data_size: 10,
+      // View and build options
+      identifiers_on_map: 'bigg_id',
+      highlight_missing: false,
+      allow_building_duplicate_reactions: false,
+      cofactors: [ 'atp', 'adp', 'nad', 'nadh', 'nadp', 'nadph', 'gtp', 'gdp',
+                   'h', 'coa', 'ump', 'h20', 'ppi' ],
+      // Extensions
+      tooltip_component: DefaultTooltip,
+      enable_tooltips: true,
+      reaction_scale_preset: null,
+      metabolite_scale_preset: null,
+      // Callbacks
+      first_load_callback: null,
+    }, {
+      primary_metabolite_radius: true,
+      secondary_metabolite_radius: true,
+      marker_radius: true,
+      gene_font_size: true,
+      reaction_no_data_size: true,
+      metabolite_no_data_size: true,
+    })
 
-  // Remember if the user provided a custom value for reaction_styles
-  this.has_custom_reaction_styles = Boolean(options.reaction_styles)
+    // Check the location
+    if (utils.check_for_parent_tag(this.selection, 'svg')) {
+      throw new Error('Builder cannot be placed within an svg node '+
+                      'because UI elements are html-based.')
+    }
 
-  // set defaults
-  this.options = utils.set_options(options, {
-    // view options
-    menu: 'all',
-    scroll_behavior: 'pan',
-    use_3d_transform: !utils.check_browser('safari'),
-    enable_editing: true,
-    enable_keys: true,
-    enable_search: true,
-    fill_screen: false,
-    zoom_to_element: null,
-    full_screen_button: false,
-    ignore_bootstrap: false,
-    disabled_buttons: null,
-    // map, model, and styles
-    starting_reaction: null,
-    never_ask_before_quit: false,
-    unique_map_id: null,
-    primary_metabolite_radius: 20,
-    secondary_metabolite_radius: 10,
-    marker_radius: 5,
-    gene_font_size: 18,
-    hide_secondary_metabolites: false,
-    show_gene_reaction_rules: false,
-    hide_all_labels: false,
-    canvas_size_and_loc: null,
-    // applied data
-    // reaction
-    reaction_data: null,
-    reaction_styles: ['color', 'size', 'text'],
-    reaction_compare_style: 'log2_fold',
-    reaction_scale: [ { type: 'min', color: '#c8c8c8', size: 12 },
-                      { type: 'median', color: '#9696ff', size: 20 },
-                      { type: 'max', color: '#ff0000', size: 25 } ],
-    reaction_no_data_color: '#dcdcdc',
-    reaction_no_data_size: 8,
-    // gene
-    gene_data: null,
-    and_method_in_gene_reaction_rule: 'mean',
-    // metabolite
-    metabolite_data: null,
-    metabolite_styles: ['color', 'size', 'text'],
-    metabolite_compare_style: 'log2_fold',
-    metabolite_scale: [ { type: 'min', color: '#fffaf0', size: 20 },
-                        { type: 'median', color: '#f1c470', size: 30 },
-                        { type: 'max', color: '#800000', size: 40 } ],
-    metabolite_no_data_color: '#ffffff',
-    metabolite_no_data_size: 10,
-    // View and build options
-    identifiers_on_map: 'bigg_id',
-    highlight_missing: false,
-    allow_building_duplicate_reactions: false,
-    cofactors: [ 'atp', 'adp', 'nad', 'nadh', 'nadp', 'nadph', 'gtp', 'gdp',
-                 'h', 'coa', 'ump', 'h20', 'ppi' ],
-    // Extensions
-    tooltip_component: DefaultTooltip,
-    enable_tooltips: true,
-    reaction_scale_preset: null,
-    metabolite_scale_preset: null,
-    // Callbacks
-    first_load_callback: null,
-  }, {
-    primary_metabolite_radius: true,
-    secondary_metabolite_radius: true,
-    marker_radius: true,
-    gene_font_size: true,
-    reaction_no_data_size: true,
-    metabolite_no_data_size: true,
-  })
+    // Initialize the settings
+    var set_option = function (option, new_value) {
+      this.options[option] = new_value
+    }.bind(this)
+    var get_option = function (option) {
+      return this.options[option]
+    }.bind(this)
+    // the options that are erased when the settings menu is canceled
+    var conditional = [ 'hide_secondary_metabolites', 'show_gene_reaction_rules',
+                        'hide_all_labels', 'scroll_behavior', 'reaction_styles',
+                        'reaction_compare_style', 'reaction_scale',
+                        'reaction_no_data_color', 'reaction_no_data_size',
+                        'and_method_in_gene_reaction_rule', 'metabolite_styles',
+                        'metabolite_compare_style', 'metabolite_scale',
+                        'metabolite_no_data_color', 'metabolite_no_data_size',
+                        'identifiers_on_map', 'highlight_missing',
+                        'allow_building_duplicate_reactions', 'enable_tooltips' ]
+    this.settings = new Settings(set_option, get_option, conditional)
 
-  // Check the location
-  if (utils.check_for_parent_tag(this.selection, 'svg')) {
-    throw new Error('Builder cannot be placed within an svg node '+
-                    'because UI elements are html-based.')
-  }
-
-  // Initialize the settings
-  var set_option = function (option, new_value) {
-    this.options[option] = new_value
-  }.bind(this)
-  var get_option = function (option) {
-    return this.options[option]
-  }.bind(this)
-  // the options that are erased when the settings menu is canceled
-  var conditional = [ 'hide_secondary_metabolites', 'show_gene_reaction_rules',
-                      'hide_all_labels', 'scroll_behavior', 'reaction_styles',
-                      'reaction_compare_style', 'reaction_scale',
-                      'reaction_no_data_color', 'reaction_no_data_size',
-                      'and_method_in_gene_reaction_rule', 'metabolite_styles',
-                      'metabolite_compare_style', 'metabolite_scale',
-                      'metabolite_no_data_color', 'metabolite_no_data_size',
-                      'identifiers_on_map', 'highlight_missing',
-                      'allow_building_duplicate_reactions', 'enable_tooltips' ]
-  this.settings = new Settings(set_option, get_option, conditional)
-
-  // Check the scales have max and min
-  var scales = [ 'reaction_scale', 'metabolite_scale' ]
-  scales.forEach(function (name) {
-    this.settings.streams[name].onValue(function (val) {
-      var types = [ 'min', 'max' ]
-      types.forEach(function (type) {
-        var has = val.reduce(function (has_found, scale_el) {
-          return has_found || (scale_el.type === type)
-        }, false)
-        if (!has) {
-          val.push({ type: type, color: '#ffffff', size: 10 })
-          this.settings.set_conditional(name, val)
-        }
+    // Check the scales have max and min
+    var scales = [ 'reaction_scale', 'metabolite_scale' ]
+    scales.forEach(function (name) {
+      this.settings.streams[name].onValue(function (val) {
+        var types = [ 'min', 'max' ]
+        types.forEach(function (type) {
+          var has = val.reduce(function (has_found, scale_el) {
+            return has_found || (scale_el.type === type)
+          }, false)
+          if (!has) {
+            val.push({ type: type, color: '#ffffff', size: 10 })
+            this.settings.set_conditional(name, val)
+          }
+        }.bind(this))
       }.bind(this))
     }.bind(this))
-  }.bind(this))
-  // TODO warn about repeated types in the scale
+    // TODO warn about repeated types in the scale
 
-  // Set up this callback manager
-  this.callback_manager = CallbackManager()
-  if (this.options.first_load_callback !== null) {
-    this.callback_manager.set('first_load', this.options.first_load_callback)
-  }
+    // Set up this callback manager
+    this.callback_manager = CallbackManager()
+    if (this.options.first_load_callback !== null) {
+      this.callback_manager.set('first_load', this.options.first_load_callback)
+    }
 
-  // Set up the zoom container
-  this.zoom_container = new ZoomContainer(this.selection,
-                                          this.options.scroll_behavior,
-                                          this.options.use_3d_transform,
-                                          this.options.fill_screen)
-  // Zoom container status changes
-  this.zoom_container.callback_manager.set('svg_start', function () {
-    if (this.map) this.map.set_status('Drawing ...')
-  }.bind(this))
-  this.zoom_container.callback_manager.set('svg_finish', function () {
-    if (this.map) this.map.set_status('')
-  }.bind(this))
+    // Set up the zoom container
+    this.zoom_container = new ZoomContainer(this.selection,
+                                            this.options.scroll_behavior,
+                                            this.options.use_3d_transform,
+                                            this.options.fill_screen)
+    // Zoom container status changes
+    this.zoom_container.callback_manager.set('svg_start', function () {
+      if (this.map) this.map.set_status('Drawing ...')
+    }.bind(this))
+    this.zoom_container.callback_manager.set('svg_finish', function () {
+      if (this.map) this.map.set_status('')
+    }.bind(this))
 
-  // Set up the tooltip container
-  this.tooltip_container = new TooltipContainer(this.selection,
-                                                this.options.tooltip_component,
-                                                this.zoom_container)
+    // Set up the tooltip container
+    this.tooltip_container = new TooltipContainer(this.selection,
+                                                  this.options.tooltip_component,
+                                                  this.zoom_container)
 
-  // Status in both modes
-  this._create_status(this.selection)
+    // Status in both modes
+    this._create_status(this.selection)
 
-  // Load the model, map, and update data in both
-  this.load_model(this.model_data, false)
+    // Load the model, map, and update data in both
+    this.load_model(this.model_data, false)
 
-  // Need to defer map loading to let webpack CSS load properly
-  _.defer(() => {
-    this.load_map(this.map_data, false)
-    const message_fn = this._reaction_check_add_abs()
-    this._update_data(true, true)
+    // Need to defer map loading to let webpack CSS load properly
+    _.defer(() => {
+      this.load_map(this.map_data, false)
+      const message_fn = this._reaction_check_add_abs()
+      this._update_data(true, true)
 
-    _.mapObject(this.settings.streams, (stream, key) => {
-      stream.onValue(value => {
-        // TODO optional if it makes sense:
-        // if (key in keysICareAbout) {
-        this.pass_settings_menu_props({
-          ...this.options,
-          map: this.map,
-          settings: this.settings
+      _.mapObject(this.settings.streams, (stream, key) => {
+        stream.onValue(value => {
+          // TODO optional if it makes sense:
+          // if (key in keysICareAbout) {
+          this.pass_settings_menu_props({
+            ...this.options,
+            map: this.map,
+            settings: this.settings
+          })
+          if (key === 'reaction_styles' || key === 'metabolite_styles') {
+            this._update_data(false, true)
+          }
+          // }
         })
-        if (key === 'reaction_styles' || key === 'metabolite_styles') {
-          this._update_data(false, true)
-        }
-        // }
       })
-    })
 
-    // Setting callbacks. TODO enable atomic updates. Right now, every time the
-    // menu closes, everything is drawn.
-    this.settings.status_bus.onValue(x => {
-      if (x === 'accept') {
-        this._update_data(true, true, [ 'reaction', 'metabolite' ], false)
-        if (this.zoom_container !== null) {
-          const new_behavior = this.settings.get_option('scroll_behavior')
-          this.zoom_container.set_scroll_behavior(new_behavior)
+      // Setting callbacks. TODO enable atomic updates. Right now, every time the
+      // menu closes, everything is drawn.
+      this.settings.status_bus.onValue(x => {
+        if (x === 'accept') {
+          this._update_data(true, true, [ 'reaction', 'metabolite' ], false)
+          if (this.zoom_container !== null) {
+            const new_behavior = this.settings.get_option('scroll_behavior')
+            this.zoom_container.set_scroll_behavior(new_behavior)
+          }
+          if (this.map !== null) {
+            this.map.draw_all_nodes(false)
+            this.map.draw_all_reactions(true, false)
+            this.map.select_none()
+          }
         }
-        if (this.map !== null) {
-          this.map.draw_all_nodes(false)
-          this.map.draw_all_reactions(true, false)
-          this.map.select_none()
-        }
-      }
+      })
+
+      // Set up quick jump
+      this._setup_quick_jump(this.selection)
+
+      this.callback_manager.run('first_load', this)
+
+      if (message_fn !== null) setTimeout(message_fn, 500)
     })
-
-    // Set up quick jump
-    this._setup_quick_jump(this.selection)
-
-    this.callback_manager.run('first_load', this)
-
-    if (message_fn !== null) setTimeout(message_fn, 500)
-  })
-}
-
-/**
- * For documentation of this function, see docs/javascript_api.rst.
- */
-function load_model (model_data, should_update_data) {
-  if (_.isUndefined(should_update_data)) {
-    should_update_data = true
   }
 
-  // Check the cobra model
-  if (_.isNull(model_data)) {
-    this.cobra_model = null
-  } else {
-    this.cobra_model = CobraModel.from_cobra_json(model_data)
-  }
-
-  if (this.map) {
-    this.map.cobra_model = this.cobra_model
-    if (should_update_data) {
-      this._update_data(true, false)
+  /**
+   * For documentation of this function, see docs/javascript_api.rst.
+   */
+    load_model (model_data, should_update_data) {
+    if (_.isUndefined(should_update_data)) {
+      should_update_data = true
     }
-    if (this.settings.get_option('highlight_missing')) {
-      this.map.draw_all_reactions(false, false)
-    }
-  }
 
-  this.callback_manager.run('load_model', null, model_data, should_update_data)
-}
-
-/**
- * For documentation of this function, see docs/javascript_api.rst
- */
-function load_map (map_data, should_update_data) {
-  if (_.isUndefined(should_update_data))
-    should_update_data = true
-
-  // Begin with some definitions
-  var selectable_mousedown_enabled = true
-  var shift_key_on = false
-
-  // remove the old builder
-  utils.remove_child_nodes(this.zoom_container.zoomed_sel)
-
-  var zoomed_sel = this.zoom_container.zoomed_sel
-  var svg = this.zoom_container.svg
-
-  // remove the old map side effects
-  if (this.map)
-    this.map.key_manager.toggle(false)
-
-  if (map_data !== null) {
-    // import map
-    this.map = Map.from_data(map_data,
-                             svg,
-                             this.embedded_css,
-                             zoomed_sel,
-                             this.zoom_container,
-                             this.settings,
-                             this.cobra_model,
-                             this.options.enable_search)
-  } else {
-    // new map
-    this.map = new Map(svg,
-                       this.embedded_css,
-                       zoomed_sel,
-                       this.zoom_container,
-                       this.settings,
-                       this.cobra_model,
-                       this.options.canvas_size_and_loc,
-                       this.options.enable_search)
-  }
-
-  // Connect status bar
-  this._setup_status(this.map)
-
-  // Set the data for the map
-  if (should_update_data)
-    this._update_data(false, true)
-
-  // Set up the reaction input with complete.ly
-  this.build_input = new BuildInput(this.selection, this.map,
-                                    this.zoom_container, this.settings)
-
-  // Set up the text edit input
-  this.text_edit_input = new TextEditInput(this.selection, this.map,
-                                           this.zoom_container)
-
-  // Connect the tooltip
-  this.tooltip_container.setup_map_callbacks(this.map)
-
-  // Set up the Brush
-  this.brush = new Brush(zoomed_sel, false, this.map, '.canvas-group')
-  this.map.canvas.callback_manager.set('resize', function () {
-    this.brush.toggle(true)
-  }.bind(this))
-
-  // Set up the modes
-  this._setup_modes(this.map, this.brush, this.zoom_container)
-
-  var s = this.selection
-    .append('div').attr('class', 'search-menu-container')
-    .append('div').attr('class', 'search-menu-container-inline')
-  this.menu_div = s.append('div')
-  this.search_bar_div = s.append('div')
-  this.button_div = this.selection.append('div')
-  this.settings_div = this.selection.append('div')
-
-  // Set up settings menu
-  preact.render(
-    <ReactWrapper
-      display={false}
-      callbackManager={this.callback_manager}
-      component={BuilderSettingsMenu}
-      refProp={instance => { this.settingsMenuRef = instance }}
-      closeMenu={() => this.pass_settings_menu_props({display: false})}
-    />,
-    this.settings_div.node(),
-    this.settings_div.node().children.length > 0
-    ? this.settings_div.node().firstChild
-    : undefined
-  )
-
-  this.renderSearchBar(true)
-
-  // Set up key manager
-  var keys = this._get_keys(
-    this.map,
-    this.zoom_container,
-    this.search_bar,
-    this.settings_bar,
-    this.options.enable_editing,
-    this.options.full_screen_button
-  )
-  this.map.key_manager.assigned_keys = keys
-  // Tell the key manager about the reaction input and search bar
-  this.map.key_manager.input_list = [
-    this.build_input,
-    this.searchBarRef,
-    () => this.settingsMenuRef,
-    this.text_edit_input,
-    this.tooltip_container
-  ]
-  // Make sure the key manager remembers all those changes
-  this.map.key_manager.update()
-  // Turn it on/off
-  this.map.key_manager.toggle(this.options.enable_keys)
-
-  // Disable clears
-  if (!this.options.reaction_data && this.options.disabled_buttons) {
-    this.options.disabled_buttons.push('Clear reaction data')
-  }
-  if (!this.options.gene_data && this.options.disabled_buttons) {
-    this.options.disabled_buttons.push('Clear gene data')
-  }
-  if (!this.options.metabolite_data && this.options.disabled_buttons) {
-    this.options.disabled_buttons.push('Clear metabolite data')
-  }
-
-  // Setup selection box
-  if (this.options.zoom_to_element) {
-    var type = this.options.zoom_to_element.type,
-    element_id = this.options.zoom_to_element.id
-    if (_.isUndefined(type) || [ 'reaction', 'node' ].indexOf(type) === -1) {
-      throw new Error('zoom_to_element type must be "reaction" or "node"')
-    }
-    if (_.isUndefined(element_id)) {
-      throw new Error('zoom_to_element must include id')
-    }
-    if (type === 'reaction') {
-      this.map.zoom_to_reaction(element_id)
-    } else if (type === 'node') {
-      this.map.zoom_to_node(element_id)
-    }
-  } else if (map_data !== null) {
-    this.map.zoom_extent_canvas()
-  } else {
-    if (this.options.starting_reaction !== null && this.cobra_model !== null) {
-      // Draw default reaction if no map is provided
-      var size = this.zoom_container.get_size()
-      var start_coords = { x: size.width / 2, y: size.height / 4 }
-      this.map.new_reaction_from_scratch(this.options.starting_reaction,
-                                         start_coords, 90)
-      this.map.zoom_extent_nodes()
+    // Check the cobra model
+    if (_.isNull(model_data)) {
+      this.cobra_model = null
     } else {
+      this.cobra_model = CobraModel.from_cobra_json(model_data)
+    }
+
+    if (this.map) {
+      this.map.cobra_model = this.cobra_model
+      if (should_update_data) {
+        this._update_data(true, false)
+      }
+      if (this.settings.get_option('highlight_missing')) {
+        this.map.draw_all_reactions(false, false)
+      }
+    }
+
+    this.callback_manager.run('load_model', null, model_data, should_update_data)
+  }
+
+  /**
+   * For documentation of this function, see docs/javascript_api.rst
+   */
+    load_map (map_data, should_update_data) {
+    if (_.isUndefined(should_update_data))
+      should_update_data = true
+
+    // Begin with some definitions
+    var selectable_mousedown_enabled = true
+    var shift_key_on = false
+
+    // remove the old builder
+    utils.remove_child_nodes(this.zoom_container.zoomed_sel)
+
+    var zoomed_sel = this.zoom_container.zoomed_sel
+    var svg = this.zoom_container.svg
+
+    // remove the old map side effects
+    if (this.map)
+      this.map.key_manager.toggle(false)
+
+    if (map_data !== null) {
+      // import map
+      this.map = Map.from_data(map_data,
+                               svg,
+                               this.embedded_css,
+                               zoomed_sel,
+                               this.zoom_container,
+                               this.settings,
+                               this.cobra_model,
+                               this.options.enable_search)
+    } else {
+      // new map
+      this.map = new Map(svg,
+                         this.embedded_css,
+                         zoomed_sel,
+                         this.zoom_container,
+                         this.settings,
+                         this.cobra_model,
+                         this.options.canvas_size_and_loc,
+                         this.options.enable_search)
+    }
+
+    // Connect status bar
+    this._setup_status(this.map)
+
+    // Set the data for the map
+    if (should_update_data)
+      this._update_data(false, true)
+
+    // Set up the reaction input with complete.ly
+    this.build_input = new BuildInput(this.selection, this.map,
+                                      this.zoom_container, this.settings)
+
+    // Set up the text edit input
+    this.text_edit_input = new TextEditInput(this.selection, this.map,
+                                             this.zoom_container)
+
+    // Connect the tooltip
+    this.tooltip_container.setup_map_callbacks(this.map)
+
+    // Set up the Brush
+    this.brush = new Brush(zoomed_sel, false, this.map, '.canvas-group')
+    this.map.canvas.callback_manager.set('resize', function () {
+      this.brush.toggle(true)
+    }.bind(this))
+
+    // Set up the modes
+    this._setup_modes(this.map, this.brush, this.zoom_container)
+
+    var s = this.selection
+      .append('div').attr('class', 'search-menu-container')
+      .append('div').attr('class', 'search-menu-container-inline')
+    this.menu_div = s.append('div')
+    this.search_bar_div = s.append('div')
+    this.button_div = this.selection.append('div')
+    this.settings_div = this.selection.append('div')
+
+    // Set up settings menu
+    preact.render(
+      <ReactWrapper
+        display={false}
+        callbackManager={this.callback_manager}
+        component={BuilderSettingsMenu}
+        refProp={instance => { this.settingsMenuRef = instance }}
+        closeMenu={() => this.pass_settings_menu_props({display: false})}
+      />,
+      this.settings_div.node(),
+      this.settings_div.node().children.length > 0
+      ? this.settings_div.node().firstChild
+      : undefined
+    )
+
+    this.renderSearchBar(true)
+
+    // Set up key manager
+    var keys = this._get_keys(
+      this.map,
+      this.zoom_container,
+      this.search_bar,
+      this.settings_bar,
+      this.options.enable_editing,
+      this.options.full_screen_button
+    )
+    this.map.key_manager.assigned_keys = keys
+    // Tell the key manager about the reaction input and search bar
+    this.map.key_manager.input_list = [
+      this.build_input,
+      this.searchBarRef,
+      () => this.settingsMenuRef,
+      this.text_edit_input,
+      this.tooltip_container
+    ]
+    // Make sure the key manager remembers all those changes
+    this.map.key_manager.update()
+    // Turn it on/off
+    this.map.key_manager.toggle(this.options.enable_keys)
+
+    // Disable clears
+    if (!this.options.reaction_data && this.options.disabled_buttons) {
+      this.options.disabled_buttons.push('Clear reaction data')
+    }
+    if (!this.options.gene_data && this.options.disabled_buttons) {
+      this.options.disabled_buttons.push('Clear gene data')
+    }
+    if (!this.options.metabolite_data && this.options.disabled_buttons) {
+      this.options.disabled_buttons.push('Clear metabolite data')
+    }
+
+    // Setup selection box
+    if (this.options.zoom_to_element) {
+      var type = this.options.zoom_to_element.type,
+      element_id = this.options.zoom_to_element.id
+      if (_.isUndefined(type) || [ 'reaction', 'node' ].indexOf(type) === -1) {
+        throw new Error('zoom_to_element type must be "reaction" or "node"')
+      }
+      if (_.isUndefined(element_id)) {
+        throw new Error('zoom_to_element must include id')
+      }
+      if (type === 'reaction') {
+        this.map.zoom_to_reaction(element_id)
+      } else if (type === 'node') {
+        this.map.zoom_to_node(element_id)
+      }
+    } else if (map_data !== null) {
       this.map.zoom_extent_canvas()
+    } else {
+      if (this.options.starting_reaction !== null && this.cobra_model !== null) {
+        // Draw default reaction if no map is provided
+        var size = this.zoom_container.get_size()
+        var start_coords = { x: size.width / 2, y: size.height / 4 }
+        this.map.new_reaction_from_scratch(this.options.starting_reaction,
+                                           start_coords, 90)
+        this.map.zoom_extent_nodes()
+      } else {
+        this.map.zoom_extent_canvas()
+      }
+    }
+
+    // Start in zoom mode for builder, view mode for viewer
+    if (this.options.enable_editing) {
+      this.zoom_mode()
+    } else {
+      this.view_mode()
+    }
+
+    // confirm before leaving the page
+    if (this.options.enable_editing) {
+      this._setup_confirm_before_exit()
+    }
+
+    // draw
+    this.map.draw_everything()
+  }
+
+    renderMenu (mode) {
+    const menuDivNode = this.menu_div.node()
+    if (this.options.menu === 'all') {
+      preact.render(
+        <BuilderMenuBar
+          {...this.options}
+          {...this.map}
+          mode={mode}
+          settings={this.settings}
+          saveMap={() => this.map.save()}
+          loadMap={(file) => this.load_map(file)}
+          saveSvg={() => this.map.save_svg()}
+          savePng={() => this.map.save_png()}
+          clearMap={() => this.map.clear_map()}
+          loadModel={file => this.load_model(file, true)}
+          updateRules={() => this.map.convert_map()}
+          loadReactionData={file => {
+            this.set_reaction_data(file)
+            this._set_mode(mode)
+          }}
+          loadGeneData={file => {
+            this.set_gene_data(file)
+            this._set_mode(mode)
+          }}
+          loadMetaboliteData={file => {
+            this.set_metabolite_data(file)
+            this._set_mode(mode)
+          }}
+          setMode={(newMode) => this._set_mode(newMode)}
+          deleteSelected={() => this.map.delete_selected()}
+          undo={() => this.map.undo_stack.undo()}
+          redo={() => this.map.undo_stack.redo()}
+          togglePrimary={() => this.map.toggle_selected_node_primary()}
+          cyclePrimary={() => this.map.cycle_primary_node()}
+          selectAll={() => this.map.select_all()}
+          selectNone={() => this.map.select_none()}
+          invertSelection={() => this.map.invert_selection()}
+          zoomIn={() => this.zoom_container.zoom_in()}
+          zoomOut={() => this.zoom_container.zoom_out()}
+          zoomExtentNodes={() => this.map.zoom_extent_nodes()}
+          zoomExtentCanvas={() => this.map.zoom_extent_canvas()}
+          search={() => this.renderSearchBar()}
+          toggleBeziers={() => this.map.toggle_beziers()}
+          renderSettingsMenu={() => this.pass_settings_menu_props({
+            ...this.options,
+            map: this.map,
+            settings: this.settings,
+            display: true
+          })}
+        />,
+        menuDivNode,
+        menuDivNode.children.length > 0 // If there is already a div, re-render it. Otherwise make a new one
+          ? menuDivNode.firstChild
+          : undefined
+      )
     }
   }
 
-  // Start in zoom mode for builder, view mode for viewer
-  if (this.options.enable_editing) {
-    this.zoom_mode()
-  } else {
-    this.view_mode()
-  }
-
-  // confirm before leaving the page
-  if (this.options.enable_editing) {
-    this._setup_confirm_before_exit()
-  }
-
-  // draw
-  this.map.draw_everything()
-}
-
-function renderMenu (mode) {
-  const menuDivNode = this.menu_div.node()
-  if (this.options.menu === 'all') {
+    renderSearchBar (hide) {
+    const searchBarNode = this.search_bar_div.node()
     preact.render(
-      <BuilderMenuBar
-        {...this.options}
-        {...this.map}
-        mode={mode}
-        settings={this.settings}
-        saveMap={() => this.map.save()}
-        loadMap={(file) => this.load_map(file)}
-        saveSvg={() => this.map.save_svg()}
-        savePng={() => this.map.save_png()}
-        clearMap={() => this.map.clear_map()}
-        loadModel={file => this.load_model(file, true)}
-        updateRules={() => this.map.convert_map()}
-        loadReactionData={file => {
-          this.set_reaction_data(file)
-          this._set_mode(mode)
-        }}
-        loadGeneData={file => {
-          this.set_gene_data(file)
-          this._set_mode(mode)
-        }}
-        loadMetaboliteData={file => {
-          this.set_metabolite_data(file)
-          this._set_mode(mode)
-        }}
-        setMode={(newMode) => this._set_mode(newMode)}
-        deleteSelected={() => this.map.delete_selected()}
-        undo={() => this.map.undo_stack.undo()}
-        redo={() => this.map.undo_stack.redo()}
-        togglePrimary={() => this.map.toggle_selected_node_primary()}
-        cyclePrimary={() => this.map.cycle_primary_node()}
-        selectAll={() => this.map.select_all()}
-        selectNone={() => this.map.select_none()}
-        invertSelection={() => this.map.invert_selection()}
-        zoomIn={() => this.zoom_container.zoom_in()}
-        zoomOut={() => this.zoom_container.zoom_out()}
-        zoomExtentNodes={() => this.map.zoom_extent_nodes()}
-        zoomExtentCanvas={() => this.map.zoom_extent_canvas()}
-        search={() => this.renderSearchBar()}
-        toggleBeziers={() => this.map.toggle_beziers()}
-        renderSettingsMenu={() => this.pass_settings_menu_props({
-          ...this.options,
-          map: this.map,
-          settings: this.settings,
-          display: true
-        })}
+      <SearchBar
+        visible={!hide}
+        searchIndex={this.map.search_index}
+        map={this.map}
+        ref={instance => { this.searchBarRef = instance }}
       />,
-      menuDivNode,
-      menuDivNode.children.length > 0 // If there is already a div, re-render it. Otherwise make a new one
-        ? menuDivNode.firstChild
+      searchBarNode,
+      searchBarNode.children.length > 0 // If there is already a div, re-render it. Otherwise make a new one
+        ? searchBarNode.firstChild
         : undefined
     )
   }
-}
 
-function renderSearchBar (hide) {
-  const searchBarNode = this.search_bar_div.node()
-  preact.render(
-    <SearchBar
-      visible={!hide}
-      searchIndex={this.map.search_index}
-      map={this.map}
-      ref={instance => { this.searchBarRef = instance }}
-    />,
-    searchBarNode,
-    searchBarNode.children.length > 0 // If there is already a div, re-render it. Otherwise make a new one
-      ? searchBarNode.firstChild
+    renderButtonPanel (mode) {
+    const buttonPanelDivNode = this.button_div.node()
+    preact.render(
+      <ButtonPanel
+        setMode={(newMode) => this._set_mode(newMode)}
+        zoomContainer={this.zoom_container}
+        map={this.map}
+        mode={mode}
+        buildInput={this.build_input}
+      />,
+    buttonPanelDivNode,
+    buttonPanelDivNode.children.length > 0 // If there is already a div, re-render it. Otherwise make a new one
+      ? buttonPanelDivNode.firstChild
       : undefined
-  )
-}
-
-function renderButtonPanel (mode) {
-  const buttonPanelDivNode = this.button_div.node()
-  preact.render(
-    <ButtonPanel
-      setMode={(newMode) => this._set_mode(newMode)}
-      zoomContainer={this.zoom_container}
-      map={this.map}
-      mode={mode}
-      buildInput={this.build_input}
-    />,
-  buttonPanelDivNode,
-  buttonPanelDivNode.children.length > 0 // If there is already a div, re-render it. Otherwise make a new one
-    ? buttonPanelDivNode.firstChild
-    : undefined
-  )
-}
-
-function _set_mode (mode) {
-  this.renderMenu(mode)
-  this.renderButtonPanel(mode)
-  // input
-  this.build_input.toggle(mode == 'build')
-  this.build_input.direction_arrow.toggle(mode == 'build')
-  // brush
-  this.brush.toggle(mode == 'brush')
-  // zoom
-  this.zoom_container.toggle_pan_drag(mode == 'zoom' || mode == 'view')
-  // resize canvas
-  this.map.canvas.toggle_resize(mode == 'zoom' || mode == 'brush')
-  // Behavior. Be careful of the order becuase rotation and
-  // toggle_selectable_drag both use Behavior.selectable_drag.
-  if (mode  ==  'rotate') {
-    this.map.behavior.toggle_selectable_drag(false) // before toggle_rotation_mode
-    this.map.behavior.toggle_rotation_mode(true)
-  } else {
-    this.map.behavior.toggle_rotation_mode(mode == 'rotate') // before toggle_selectable_drag
-    this.map.behavior.toggle_selectable_drag(mode == 'brush')
-  }
-  this.map.behavior.toggle_selectable_click(mode == 'build' || mode == 'brush')
-  this.map.behavior.toggle_label_drag(mode == 'brush')
-  this.map.behavior.toggle_label_mouseover(true)
-  this.map.behavior.toggle_label_touch(true)
-  this.map.behavior.toggle_text_label_edit(mode == 'text')
-  this.map.behavior.toggle_bezier_drag(mode == 'brush')
-  // edit selections
-  if (mode == 'view' || mode == 'text')
-    this.map.select_none()
-  if (mode == 'rotate')
-    this.map.deselect_text_labels()
-  this.map.draw_everything()
-}
-
-function view_mode () {
-  /** For documentation of this function, see docs/javascript_api.rst.  */
-  this.callback_manager.run('view_mode')
-  this._set_mode('view')
-}
-
-function build_mode () {
-  /** For documentation of this function, see docs/javascript_api.rst.  */
-  this.callback_manager.run('build_mode')
-  this._set_mode('build')
-}
-
-function brush_mode () {
-  console.log('pressed')
-  /** For documentation of this function, see docs/javascript_api.rst.  */
-  this.callback_manager.run('brush_mode')
-  this._set_mode('brush')
-}
-
-function zoom_mode () {
-  /** For documentation of this function, see docs/javascript_api.rst.  */
-  this.callback_manager.run('zoom_mode')
-  this._set_mode('zoom')
-}
-
-function rotate_mode () {
-  /** For documentation of this function, see docs/javascript_api.rst.  */
-  this.callback_manager.run('rotate_mode')
-  this._set_mode('rotate')
-}
-
-function text_mode () {
-  /** For documentation of this function, see docs/javascript_api.rst.  */
-  this.callback_manager.run('text_mode')
-  this._set_mode('text')
-}
-
-function _reaction_check_add_abs () {
-  var curr_style = this.options.reaction_styles
-  var did_abs = false
-  if (this.options.reaction_data !== null &&
-      !this.has_custom_reaction_styles &&
-      !_.contains(curr_style, 'abs')) {
-    this.settings.set_conditional('reaction_styles', curr_style.concat('abs'))
-    return function () {
-      this.map.set_status('Visualizing absolute value of reaction data. ' +
-                          'Change this option in Settings.', 5000)
-    }.bind(this)
-  }
-  return null
-}
-
-/**
- * Function to get props for the tooltip component
- * @param {Object} props - Props that the tooltip will use
- */
-function pass_tooltip_component_props (props) {
-  this.tooltip_container.callback_manager.run('setState', null, props)
-}
-
-/**
- * Function to get props for the settings menu
- * @param {Object} props - Props that the settings menu will use
- */
-function pass_settings_menu_props (props) {
-  // if (this.settings_menu.visible) { // <- pseudocode
-    // pass the props
-  // }
-  this.callback_manager.run('setState', null, props)
-}
-
-/**
- * For documentation of this function, see docs/javascript_api.rst.
- */
-function set_reaction_data (data) {
-  this.options.reaction_data = data
-  var message_fn = this._reaction_check_add_abs()
-  this._update_data(true, true, 'reaction')
-  if (message_fn) {
-    message_fn()
-  } else {
-    this.map.set_status('')
+    )
   }
 
-  let index = this.options.disabled_buttons.indexOf('Clear reaction data')
-  if (index > -1) {
-    this.options.disabled_buttons.splice(index, 1)
-  } else if (index === -1 && data === null) {
-    this.options.disabled_buttons.push('Clear reaction data')
+    _set_mode (mode) {
+    this.renderMenu(mode)
+    this.renderButtonPanel(mode)
+    // input
+    this.build_input.toggle(mode == 'build')
+    this.build_input.direction_arrow.toggle(mode == 'build')
+    // brush
+    this.brush.toggle(mode == 'brush')
+    // zoom
+    this.zoom_container.toggle_pan_drag(mode == 'zoom' || mode == 'view')
+    // resize canvas
+    this.map.canvas.toggle_resize(mode == 'zoom' || mode == 'brush')
+    // Behavior. Be careful of the order becuase rotation and
+    // toggle_selectable_drag both use Behavior.selectable_drag.
+    if (mode  ==  'rotate') {
+      this.map.behavior.toggle_selectable_drag(false) // before toggle_rotation_mode
+      this.map.behavior.toggle_rotation_mode(true)
+    } else {
+      this.map.behavior.toggle_rotation_mode(mode == 'rotate') // before toggle_selectable_drag
+      this.map.behavior.toggle_selectable_drag(mode == 'brush')
+    }
+    this.map.behavior.toggle_selectable_click(mode == 'build' || mode == 'brush')
+    this.map.behavior.toggle_label_drag(mode == 'brush')
+    this.map.behavior.toggle_label_mouseover(true)
+    this.map.behavior.toggle_label_touch(true)
+    this.map.behavior.toggle_text_label_edit(mode == 'text')
+    this.map.behavior.toggle_bezier_drag(mode == 'brush')
+    // edit selections
+    if (mode == 'view' || mode == 'text')
+      this.map.select_none()
+    if (mode == 'rotate')
+      this.map.deselect_text_labels()
+    this.map.draw_everything()
   }
-}
 
-/**
- * For documentation of this function, see docs/javascript_api.rst.
- */
-function set_gene_data (data, clear_gene_reaction_rules) {
-  if (clear_gene_reaction_rules) {
-    // default undefined
-    this.settings.set_conditional('show_gene_reaction_rules', false)
+    view_mode () {
+    /** For documentation of this function, see docs/javascript_api.rst.  */
+    this.callback_manager.run('view_mode')
+    this._set_mode('view')
   }
-  this.options.gene_data = data
-  this._update_data(true, true, 'reaction')
-  this.map.set_status('')
 
-  let index = this.options.disabled_buttons.indexOf('Clear gene data')
-  if (index > -1) {
-    this.options.disabled_buttons.splice(index, 1)
-  } else if (index === -1 && data === null) {
-    this.options.disabled_buttons.push('Clear gene data')
+    build_mode () {
+    /** For documentation of this function, see docs/javascript_api.rst.  */
+    this.callback_manager.run('build_mode')
+    this._set_mode('build')
   }
-}
 
-function set_metabolite_data (data) {
-  /** For documentation of this function, see docs/javascript_api.rst.
+    brush_mode () {
+    console.log('pressed')
+    /** For documentation of this function, see docs/javascript_api.rst.  */
+    this.callback_manager.run('brush_mode')
+    this._set_mode('brush')
+  }
 
+    zoom_mode () {
+    /** For documentation of this function, see docs/javascript_api.rst.  */
+    this.callback_manager.run('zoom_mode')
+    this._set_mode('zoom')
+  }
+
+    rotate_mode () {
+    /** For documentation of this function, see docs/javascript_api.rst.  */
+    this.callback_manager.run('rotate_mode')
+    this._set_mode('rotate')
+  }
+
+    text_mode () {
+    /** For documentation of this function, see docs/javascript_api.rst.  */
+    this.callback_manager.run('text_mode')
+    this._set_mode('text')
+  }
+
+    _reaction_check_add_abs () {
+    var curr_style = this.options.reaction_styles
+    var did_abs = false
+    if (this.options.reaction_data !== null &&
+        !this.has_custom_reaction_styles &&
+        !_.contains(curr_style, 'abs')) {
+      this.settings.set_conditional('reaction_styles', curr_style.concat('abs'))
+      return function () {
+        this.map.set_status('Visualizing absolute value of reaction data. ' +
+                            'Change this option in Settings.', 5000)
+      }.bind(this)
+    }
+    return null
+  }
+
+  /**
+   * Function to get props for the tooltip component
+   * @param {Object} props - Props that the tooltip will use
    */
-  this.options.metabolite_data = data
-  this._update_data(true, true, 'metabolite')
-  this.map.set_status('')
-
-  let index = this.options.disabled_buttons.indexOf('Clear metabolite data')
-  if (index > -1) {
-    this.options.disabled_buttons.splice(index, 1)
-  } else if (index === -1 && data === null) {
-    this.options.disabled_buttons.push('Clear metabolite data')
-  }
-}
-
-/**
- * Set data and settings for the model.
- * update_model: (Boolean) Update data for the model.
- * update_map: (Boolean) Update data for the map.
- * kind: (Optional, Default: all) An array defining which data is being updated
- * that can include any of: ['reaction', 'metabolite'].
- * should_draw: (Optional, Default: true) Whether to redraw the update sections
- * of the map.
- */
-function _update_data (update_model, update_map, kind, should_draw) {
-  // defaults
-  if (kind === undefined) {
-    kind = [ 'reaction', 'metabolite' ]
-  }
-  if (should_draw === undefined) {
-    should_draw = true
+    pass_tooltip_component_props (props) {
+    this.tooltip_container.callback_manager.run('setState', null, props)
   }
 
-  var update_metabolite_data = (kind.indexOf('metabolite') !== -1)
-  var update_reaction_data = (kind.indexOf('reaction') !== -1)
-  var met_data_object
-  var reaction_data_object
-  var gene_data_object
+  /**
+   * Function to get props for the settings menu
+   * @param {Object} props - Props that the settings menu will use
+   */
+    pass_settings_menu_props (props) {
+    // if (this.settings_menu.visible) { // <- pseudocode
+      // pass the props
+    // }
+    this.callback_manager.run('setState', null, props)
+  }
 
-  // -------------------
-  // First map, and draw
-  // -------------------
+  /**
+   * For documentation of this function, see docs/javascript_api.rst.
+   */
+    set_reaction_data (data) {
+    this.options.reaction_data = data
+    var message_fn = this._reaction_check_add_abs()
+    this._update_data(true, true, 'reaction')
+    if (message_fn) {
+      message_fn()
+    } else {
+      this.map.set_status('')
+    }
 
-  // metabolite data
-  if (update_metabolite_data && update_map && this.map !== null) {
-    met_data_object = data_styles.import_and_check(this.options.metabolite_data,
-                                                   'metabolite_data')
-    this.map.apply_metabolite_data_to_map(met_data_object)
-    if (should_draw) {
-      this.map.draw_all_nodes(false)
+    let index = this.options.disabled_buttons.indexOf('Clear reaction data')
+    if (index > -1) {
+      this.options.disabled_buttons.splice(index, 1)
+    } else if (index === -1 && data === null) {
+      this.options.disabled_buttons.push('Clear reaction data')
     }
   }
 
-  // reaction data
-  if (update_reaction_data) {
-    if (this.options.reaction_data !== null && update_map && this.map !== null) {
-      reaction_data_object = data_styles.import_and_check(this.options.reaction_data,
-                                                          'reaction_data')
-      this.map.apply_reaction_data_to_map(reaction_data_object)
-      if (should_draw)
-        this.map.draw_all_reactions(false, false)
-    } else if (this.options.gene_data !== null && update_map && this.map !== null) {
-      gene_data_object = make_gene_data_object(this.options.gene_data,
-                                               this.cobra_model, this.map)
-      this.map.apply_gene_data_to_map(gene_data_object)
-      if (should_draw)
-        this.map.draw_all_reactions(false, false)
-    } else if (update_map && this.map !== null) {
-      // clear the data
-      this.map.apply_reaction_data_to_map(null)
-      if (should_draw)
-        this.map.draw_all_reactions(false, false)
+  /**
+   * For documentation of this function, see docs/javascript_api.rst.
+   */
+    set_gene_data (data, clear_gene_reaction_rules) {
+    if (clear_gene_reaction_rules) {
+      // default undefined
+      this.settings.set_conditional('show_gene_reaction_rules', false)
+    }
+    this.options.gene_data = data
+    this._update_data(true, true, 'reaction')
+    this.map.set_status('')
+
+    let index = this.options.disabled_buttons.indexOf('Clear gene data')
+    if (index > -1) {
+      this.options.disabled_buttons.splice(index, 1)
+    } else if (index === -1 && data === null) {
+      this.options.disabled_buttons.push('Clear gene data')
     }
   }
 
-  // ----------------------------------------------------------------
-  // Then the model, after drawing. Delay by 5ms so the the map draws
-  // first.
-  // ----------------------------------------------------------------
+    set_metabolite_data (data) {
+    /** For documentation of this function, see docs/javascript_api.rst.
 
-  // If this function runs again, cancel the previous model update
-  if (this.update_model_timer) {
-    clearTimeout(this.update_model_timer)
+     */
+    this.options.metabolite_data = data
+    this._update_data(true, true, 'metabolite')
+    this.map.set_status('')
+
+    let index = this.options.disabled_buttons.indexOf('Clear metabolite data')
+    if (index > -1) {
+      this.options.disabled_buttons.splice(index, 1)
+    } else if (index === -1 && data === null) {
+      this.options.disabled_buttons.push('Clear metabolite data')
+    }
   }
 
-  var delay = 5
-  this.update_model_timer = setTimeout(function () {
+  /**
+   * Set data and settings for the model.
+   * update_model: (Boolean) Update data for the model.
+   * update_map: (Boolean) Update data for the map.
+   * kind: (Optional, Default: all) An array defining which data is being updated
+   * that can include any of: ['reaction', 'metabolite'].
+   * should_draw: (Optional, Default: true) Whether to redraw the update sections
+   * of the map.
+   */
+    _update_data (update_model, update_map, kind, should_draw) {
+    // defaults
+    if (kind === undefined) {
+      kind = [ 'reaction', 'metabolite' ]
+    }
+    if (should_draw === undefined) {
+      should_draw = true
+    }
 
-    // metabolite_data
-    if (update_metabolite_data && update_model && this.cobra_model !== null) {
-      // if we haven't already made this
-      if (!met_data_object) {
-        met_data_object = data_styles.import_and_check(this.options.metabolite_data,
-                                                       'metabolite_data')
+    var update_metabolite_data = (kind.indexOf('metabolite') !== -1)
+    var update_reaction_data = (kind.indexOf('reaction') !== -1)
+    var met_data_object
+    var reaction_data_object
+    var gene_data_object
+
+    // -------------------
+    // First map, and draw
+    // -------------------
+
+    // metabolite data
+    if (update_metabolite_data && update_map && this.map !== null) {
+      met_data_object = data_styles.import_and_check(this.options.metabolite_data,
+                                                     'metabolite_data')
+      this.map.apply_metabolite_data_to_map(met_data_object)
+      if (should_draw) {
+        this.map.draw_all_nodes(false)
       }
-      this.cobra_model.apply_metabolite_data(met_data_object,
-                                             this.options.metabolite_styles,
-                                             this.options.metabolite_compare_style)
     }
 
     // reaction data
     if (update_reaction_data) {
-      if (this.options.reaction_data !== null && update_model && this.cobra_model !== null) {
-        // if we haven't already made this
-        if (!reaction_data_object) {
-          reaction_data_object = data_styles.import_and_check(this.options.reaction_data,
-                                                              'reaction_data')
-        }
-        this.cobra_model.apply_reaction_data(reaction_data_object,
-                                             this.options.reaction_styles,
-                                             this.options.reaction_compare_style)
-      } else if (this.options.gene_data !== null && update_model && this.cobra_model !== null) {
-        if (!gene_data_object) {
-          gene_data_object = make_gene_data_object(this.options.gene_data,
-                                                   this.cobra_model, this.map)
-        }
-        this.cobra_model.apply_gene_data(gene_data_object,
-                                         this.options.reaction_styles,
-                                         this.options.identifiers_on_map,
-                                         this.options.reaction_compare_style,
-                                         this.options.and_method_in_gene_reaction_rule)
-      } else if (update_model && this.cobra_model !== null) {
+      if (this.options.reaction_data !== null && update_map && this.map !== null) {
+        reaction_data_object = data_styles.import_and_check(this.options.reaction_data,
+                                                            'reaction_data')
+        this.map.apply_reaction_data_to_map(reaction_data_object)
+        if (should_draw)
+          this.map.draw_all_reactions(false, false)
+      } else if (this.options.gene_data !== null && update_map && this.map !== null) {
+        gene_data_object = make_gene_data_object(this.options.gene_data,
+                                                 this.cobra_model, this.map)
+        this.map.apply_gene_data_to_map(gene_data_object)
+        if (should_draw)
+          this.map.draw_all_reactions(false, false)
+      } else if (update_map && this.map !== null) {
         // clear the data
-        this.cobra_model.apply_reaction_data(null,
-                                             this.options.reaction_styles,
-                                             this.options.reaction_compare_style)
+        this.map.apply_reaction_data_to_map(null)
+        if (should_draw)
+          this.map.draw_all_reactions(false, false)
       }
     }
 
-    // callback
-    this.callback_manager.run('update_data', null, update_model, update_map,
-                              kind, should_draw)
+    // ----------------------------------------------------------------
+    // Then the model, after drawing. Delay by 5ms so the the map draws
+    // first.
+    // ----------------------------------------------------------------
 
-  }.bind(this), delay)
+    // If this function runs again, cancel the previous model update
+    if (this.update_model_timer) {
+      clearTimeout(this.update_model_timer)
+    }
 
-  // definitions
-  function make_gene_data_object(gene_data, cobra_model, map) {
-    var all_reactions = {}
-    if (cobra_model !== null)
-      utils.extend(all_reactions, cobra_model.reactions)
-    // extend, overwrite
-    if (map !== null)
-      utils.extend(all_reactions, map.reactions, true)
+    var delay = 5
+    this.update_model_timer = setTimeout(function () {
 
-    // this object has reaction keys and values containing associated genes
-    return data_styles.import_and_check(gene_data, 'gene_data', all_reactions)
+      // metabolite_data
+      if (update_metabolite_data && update_model && this.cobra_model !== null) {
+        // if we haven't already made this
+        if (!met_data_object) {
+          met_data_object = data_styles.import_and_check(this.options.metabolite_data,
+                                                         'metabolite_data')
+        }
+        this.cobra_model.apply_metabolite_data(met_data_object,
+                                               this.options.metabolite_styles,
+                                               this.options.metabolite_compare_style)
+      }
+
+      // reaction data
+      if (update_reaction_data) {
+        if (this.options.reaction_data !== null && update_model && this.cobra_model !== null) {
+          // if we haven't already made this
+          if (!reaction_data_object) {
+            reaction_data_object = data_styles.import_and_check(this.options.reaction_data,
+                                                                'reaction_data')
+          }
+          this.cobra_model.apply_reaction_data(reaction_data_object,
+                                               this.options.reaction_styles,
+                                               this.options.reaction_compare_style)
+        } else if (this.options.gene_data !== null && update_model && this.cobra_model !== null) {
+          if (!gene_data_object) {
+            gene_data_object = make_gene_data_object(this.options.gene_data,
+                                                     this.cobra_model, this.map)
+          }
+          this.cobra_model.apply_gene_data(gene_data_object,
+                                           this.options.reaction_styles,
+                                           this.options.identifiers_on_map,
+                                           this.options.reaction_compare_style,
+                                           this.options.and_method_in_gene_reaction_rule)
+        } else if (update_model && this.cobra_model !== null) {
+          // clear the data
+          this.cobra_model.apply_reaction_data(null,
+                                               this.options.reaction_styles,
+                                               this.options.reaction_compare_style)
+        }
+      }
+
+      // callback
+      this.callback_manager.run('update_data', null, update_model, update_map,
+                                kind, should_draw)
+
+    }.bind(this), delay)
+
+    // definitions
+    function make_gene_data_object(gene_data, cobra_model, map) {
+      var all_reactions = {}
+      if (cobra_model !== null)
+        utils.extend(all_reactions, cobra_model.reactions)
+      // extend, overwrite
+      if (map !== null)
+        utils.extend(all_reactions, map.reactions, true)
+
+      // this object has reaction keys and values containing associated genes
+      return data_styles.import_and_check(gene_data, 'gene_data', all_reactions)
+    }
   }
-}
 
-function _create_status (selection) {
-  this.status_bar = selection.append('div').attr('id', 'status')
-}
+    _create_status (selection) {
+    this.status_bar = selection.append('div').attr('id', 'status')
+  }
 
-function _setup_status (map) {
-  map.callback_manager.set('set_status', status => this.status_bar.html(status))
-}
+    _setup_status (map) {
+    map.callback_manager.set('set_status', status => this.status_bar.html(status))
+  }
 
-function _setup_quick_jump (selection) {
-  // function to load a map
-  var load_fn = function (new_map_name, quick_jump_path, callback) {
-    if (this.options.enable_editing && !this.options.never_ask_before_quit) {
-      if (!(confirm(('You will lose any unsaved changes.\n\n' +
-                     'Are you sure you want to switch maps?')))) {
-        if (callback) callback(false)
-        return
+    _setup_quick_jump (selection) {
+    // function to load a map
+    var load_fn = function (new_map_name, quick_jump_path, callback) {
+      if (this.options.enable_editing && !this.options.never_ask_before_quit) {
+        if (!(confirm(('You will lose any unsaved changes.\n\n' +
+                       'Are you sure you want to switch maps?')))) {
+          if (callback) callback(false)
+          return
+        }
       }
+      this.map.set_status('Loading map ' + new_map_name + ' ...')
+      var url = utils.name_to_url(new_map_name, quick_jump_path)
+      d3_json(url, function (error, data) {
+        if (error) {
+          console.warn('Could not load data: ' + error)
+          this.map.set_status('Could not load map', 2000)
+          if (callback) callback(false)
+          return
+        }
+        // run callback before load_map so the new map has the correct
+        // quick_jump menu
+        if (callback) callback(true)
+        // now reload
+        this.load_map(data)
+        this.map.set_status('')
+      }.bind(this))
+    }.bind(this)
+
+    // make the quick jump object
+    this.quick_jump = QuickJump(selection, load_fn)
+  }
+
+    _setup_modes (map, brush, zoom_container) {
+    // set up zoom+pan and brush modes
+    var was_enabled = {}
+    map.callback_manager.set('start_rotation', function () {
+      was_enabled.brush = brush.enabled
+      brush.toggle(false)
+      was_enabled.zoom = zoom_container.zoom_on
+      zoom_container.toggle_pan_drag(false)
+      was_enabled.selectable_mousedown = map.behavior.selectable_mousedown !== null
+      map.behavior.toggle_selectable_click(false)
+      was_enabled.label_mouseover = map.behavior.label_mouseover !== null
+      was_enabled.label_touch = map.behavior.label_touch !== null
+      map.behavior.toggle_label_mouseover(false)
+      map.behavior.toggle_label_touch(false)
+    })
+    map.callback_manager.set('end_rotation', function () {
+      brush.toggle(was_enabled.brush)
+      zoom_container.toggle_pan_drag(was_enabled.zoom)
+      map.behavior.toggle_selectable_click(was_enabled.selectable_mousedown)
+      map.behavior.toggle_label_mouseover(was_enabled.label_mouseover)
+      map.behavior.toggle_label_touch(was_enabled.label_touch)
+      was_enabled = {}
+    })
+  }
+
+  /**
+   * Define keyboard shortcuts
+   */
+    _get_keys (map, zoom_container, search_bar, settings_bar,
+                      enable_editing, full_screen_button) {
+
+    var keys = {
+      save: {
+        key: 'ctrl+s',
+        target: map,
+        fn: map.save,
+      },
+      save_svg: {
+        key: 'ctrl+shift+s',
+        target: map,
+        fn: map.save_svg,
+      },
+      save_png: {
+        key: 'ctrl+shift+p',
+        target: map,
+        fn: map.save_png,
+      },
+      load: {
+        key: 'ctrl+o',
+        fn: null, // defined by button
+      },
+      convert_map: {
+        target: map,
+        fn: map.convert_map,
+      },
+      clear_map: {
+        target: map,
+        fn: map.clear_map,
+      },
+      load_model: {
+        key: 'ctrl+m',
+        fn: null, // defined by button
+      },
+      clear_model: {
+        fn: this.load_model.bind(this, null, true),
+      },
+      load_reaction_data: { fn: null }, // defined by button
+      clear_reaction_data: {
+        target: this,
+        fn: function () { this.set_reaction_data(null) },
+      },
+      load_metabolite_data: { fn: null }, // defined by button
+      clear_metabolite_data: {
+        target: this,
+        fn: function () { this.set_metabolite_data(null) },
+      },
+      load_gene_data: { fn: null }, // defined by button
+      clear_gene_data: {
+        target: this,
+        fn: function () { this.set_gene_data(null, true) },
+      },
+      zoom_in_ctrl: {
+        key: 'ctrl+=',
+        target: zoom_container,
+        fn: zoom_container.zoom_in,
+      },
+      zoom_in: {
+        key: '=',
+        target: zoom_container,
+        fn: zoom_container.zoom_in,
+        ignore_with_input: true,
+      },
+      zoom_out_ctrl: {
+        key: 'ctrl+-',
+        target: zoom_container,
+        fn: zoom_container.zoom_out,
+      },
+      zoom_out: {
+        key: '-',
+        target: zoom_container,
+        fn: zoom_container.zoom_out,
+        ignore_with_input: true,
+      },
+      extent_nodes_ctrl: {
+        key: 'ctrl+0',
+        target: map,
+        fn: map.zoom_extent_nodes,
+      },
+      extent_nodes: {
+        key: '0',
+        target: map,
+        fn: map.zoom_extent_nodes,
+        ignore_with_input: true,
+      },
+      extent_canvas_ctrl: {
+        key: 'ctrl+1',
+        target: map,
+        fn: map.zoom_extent_canvas,
+      },
+      extent_canvas: {
+        key: '1',
+        target: map,
+        fn: map.zoom_extent_canvas,
+        ignore_with_input: true,
+      },
+      search_ctrl: {
+        key: 'ctrl+f',
+        fn: () => this.renderSearchBar(),
+      },
+      search: {
+        key: 'f',
+        fn: () => this.renderSearchBar(),
+        ignore_with_input: true,
+      },
+      view_mode: {
+        target: this,
+        fn: this.view_mode,
+        ignore_with_input: true,
+      },
+      show_settings_ctrl: {
+        key: 'ctrl+,',
+        target: settings_bar,
+        fn: () => this.pass_settings_menu_props({
+          ...this.options,
+          map: this.map,
+          settings: this.settings,
+          display: true
+        })
+      },
+      show_settings: {
+        key: ',',
+        target: this,
+        fn: () => this.pass_settings_menu_props({
+          ...this.options,
+          map: this.map,
+          settings: this.settings,
+          display: true
+        }),
+        ignore_with_input: true,
+      },
     }
-    this.map.set_status('Loading map ' + new_map_name + ' ...')
-    var url = utils.name_to_url(new_map_name, quick_jump_path)
-    d3_json(url, function (error, data) {
-      if (error) {
-        console.warn('Could not load data: ' + error)
-        this.map.set_status('Could not load map', 2000)
-        if (callback) callback(false)
-        return
-      }
-      // run callback before load_map so the new map has the correct
-      // quick_jump menu
-      if (callback) callback(true)
-      // now reload
-      this.load_map(data)
-      this.map.set_status('')
-    }.bind(this))
-  }.bind(this)
-
-  // make the quick jump object
-  this.quick_jump = QuickJump(selection, load_fn)
-}
-
-function _setup_modes (map, brush, zoom_container) {
-  // set up zoom+pan and brush modes
-  var was_enabled = {}
-  map.callback_manager.set('start_rotation', function () {
-    was_enabled.brush = brush.enabled
-    brush.toggle(false)
-    was_enabled.zoom = zoom_container.zoom_on
-    zoom_container.toggle_pan_drag(false)
-    was_enabled.selectable_mousedown = map.behavior.selectable_mousedown !== null
-    map.behavior.toggle_selectable_click(false)
-    was_enabled.label_mouseover = map.behavior.label_mouseover !== null
-    was_enabled.label_touch = map.behavior.label_touch !== null
-    map.behavior.toggle_label_mouseover(false)
-    map.behavior.toggle_label_touch(false)
-  })
-  map.callback_manager.set('end_rotation', function () {
-    brush.toggle(was_enabled.brush)
-    zoom_container.toggle_pan_drag(was_enabled.zoom)
-    map.behavior.toggle_selectable_click(was_enabled.selectable_mousedown)
-    map.behavior.toggle_label_mouseover(was_enabled.label_mouseover)
-    map.behavior.toggle_label_touch(was_enabled.label_touch)
-    was_enabled = {}
-  })
-}
-
-/**
- * Define keyboard shortcuts
- */
-function _get_keys (map, zoom_container, search_bar, settings_bar,
-                    enable_editing, full_screen_button) {
-
-  var keys = {
-    save: {
-      key: 'ctrl+s',
-      target: map,
-      fn: map.save,
-    },
-    save_svg: {
-      key: 'ctrl+shift+s',
-      target: map,
-      fn: map.save_svg,
-    },
-    save_png: {
-      key: 'ctrl+shift+p',
-      target: map,
-      fn: map.save_png,
-    },
-    load: {
-      key: 'ctrl+o',
-      fn: null, // defined by button
-    },
-    convert_map: {
-      target: map,
-      fn: map.convert_map,
-    },
-    clear_map: {
-      target: map,
-      fn: map.clear_map,
-    },
-    load_model: {
-      key: 'ctrl+m',
-      fn: null, // defined by button
-    },
-    clear_model: {
-      fn: this.load_model.bind(this, null, true),
-    },
-    load_reaction_data: { fn: null }, // defined by button
-    clear_reaction_data: {
-      target: this,
-      fn: function () { this.set_reaction_data(null) },
-    },
-    load_metabolite_data: { fn: null }, // defined by button
-    clear_metabolite_data: {
-      target: this,
-      fn: function () { this.set_metabolite_data(null) },
-    },
-    load_gene_data: { fn: null }, // defined by button
-    clear_gene_data: {
-      target: this,
-      fn: function () { this.set_gene_data(null, true) },
-    },
-    zoom_in_ctrl: {
-      key: 'ctrl+=',
-      target: zoom_container,
-      fn: zoom_container.zoom_in,
-    },
-    zoom_in: {
-      key: '=',
-      target: zoom_container,
-      fn: zoom_container.zoom_in,
-      ignore_with_input: true,
-    },
-    zoom_out_ctrl: {
-      key: 'ctrl+-',
-      target: zoom_container,
-      fn: zoom_container.zoom_out,
-    },
-    zoom_out: {
-      key: '-',
-      target: zoom_container,
-      fn: zoom_container.zoom_out,
-      ignore_with_input: true,
-    },
-    extent_nodes_ctrl: {
-      key: 'ctrl+0',
-      target: map,
-      fn: map.zoom_extent_nodes,
-    },
-    extent_nodes: {
-      key: '0',
-      target: map,
-      fn: map.zoom_extent_nodes,
-      ignore_with_input: true,
-    },
-    extent_canvas_ctrl: {
-      key: 'ctrl+1',
-      target: map,
-      fn: map.zoom_extent_canvas,
-    },
-    extent_canvas: {
-      key: '1',
-      target: map,
-      fn: map.zoom_extent_canvas,
-      ignore_with_input: true,
-    },
-    search_ctrl: {
-      key: 'ctrl+f',
-      fn: () => this.renderSearchBar(),
-    },
-    search: {
-      key: 'f',
-      fn: () => this.renderSearchBar(),
-      ignore_with_input: true,
-    },
-    view_mode: {
-      target: this,
-      fn: this.view_mode,
-      ignore_with_input: true,
-    },
-    show_settings_ctrl: {
-      key: 'ctrl+,',
-      target: settings_bar,
-      fn: () => this.pass_settings_menu_props({
-        ...this.options,
-        map: this.map,
-        settings: this.settings,
-        display: true
+    if (full_screen_button) {
+      utils.extend(keys, {
+        full_screen_ctrl: {
+          key: 'ctrl+2',
+          target: map,
+          fn: map.full_screen,
+        },
+        full_screen: {
+          key: '2',
+          target: map,
+          fn: map.full_screen,
+          ignore_with_input: true,
+        },
       })
-    },
-    show_settings: {
-      key: ',',
-      target: this,
-      fn: () => this.pass_settings_menu_props({
-        ...this.options,
-        map: this.map,
-        settings: this.settings,
-        display: true
-      }),
-      ignore_with_input: true,
-    },
+    }
+    if (enable_editing) {
+      utils.extend(keys, {
+        build_mode: {
+          key: 'n',
+          target: this,
+          fn: this.build_mode,
+          ignore_with_input: true,
+        },
+        zoom_mode: {
+          key: 'z',
+          target: this,
+          fn: this.zoom_mode,
+          ignore_with_input: true,
+        },
+        brush_mode: {
+          key: 'v',
+          target: this,
+          fn: this.brush_mode,
+          ignore_with_input: true,
+        },
+        rotate_mode: {
+          key: 'r',
+          target: this,
+          fn: this.rotate_mode,
+          ignore_with_input: true,
+        },
+        text_mode: {
+          key: 't',
+          target: this,
+          fn: this.text_mode,
+          ignore_with_input: true,
+        },
+        toggle_beziers: {
+          key: 'b',
+          target: map,
+          fn: map.toggle_beziers,
+          ignore_with_input: true,
+        },
+        delete_ctrl: {
+          key: 'ctrl+backspace',
+          target: map,
+          fn: map.delete_selected,
+          ignore_with_input: true,
+        },
+        delete: {
+          key: 'backspace',
+          target: map,
+          fn: map.delete_selected,
+          ignore_with_input: true,
+        },
+        delete_del: {
+          key: 'del',
+          target: map,
+          fn: map.delete_selected,
+          ignore_with_input: true,
+        },
+        toggle_primary: {
+          key: 'p',
+          target: map,
+          fn: map.toggle_selected_node_primary,
+          ignore_with_input: true,
+        },
+        cycle_primary: {
+          key: 'c',
+          target: map,
+          fn: map.cycle_primary_node,
+          ignore_with_input: true,
+        },
+        direction_arrow_right: {
+          key: 'right',
+          target: this.build_input.direction_arrow,
+          fn: this.build_input.direction_arrow.right,
+          ignore_with_input: true,
+        },
+        direction_arrow_down: {
+          key: 'down',
+          target: this.build_input.direction_arrow,
+          fn: this.build_input.direction_arrow.down,
+          ignore_with_input: true,
+        },
+        direction_arrow_left: {
+          key: 'left',
+          target: this.build_input.direction_arrow,
+          fn: this.build_input.direction_arrow.left,
+          ignore_with_input: true,
+        },
+        direction_arrow_up: {
+          key: 'up',
+          target: this.build_input.direction_arrow,
+          fn: this.build_input.direction_arrow.up,
+          ignore_with_input: true,
+        },
+        undo: {
+          key: 'ctrl+z',
+          target: map.undo_stack,
+          fn: map.undo_stack.undo,
+        },
+        redo: {
+          key: 'ctrl+shift+z',
+          target: map.undo_stack,
+          fn: map.undo_stack.redo,
+        },
+        select_all: {
+          key: 'ctrl+a',
+          target: map,
+          fn: map.select_all,
+        },
+        select_none: {
+          key: 'ctrl+shift+a',
+          target: map,
+          fn: map.select_none,
+        },
+        invert_selection: {
+          target: map,
+          fn: map.invert_selection,
+        },
+      })
+    }
+    return keys
   }
-  if (full_screen_button) {
-    utils.extend(keys, {
-      full_screen_ctrl: {
-        key: 'ctrl+2',
-        target: map,
-        fn: map.full_screen,
-      },
-      full_screen: {
-        key: '2',
-        target: map,
-        fn: map.full_screen,
-        ignore_with_input: true,
-      },
-    })
+
+  /**
+   * Ask if the user wants to exit the page (to avoid unplanned refresh).
+   */
+    _setup_confirm_before_exit () {
+    window.onbeforeunload = function (e) {
+      // If we haven't been passed the event get the window.event
+      e = e || window.event
+      return  (this.options.never_ask_before_quit ? null :
+               'You will lose any unsaved changes.')
+    }.bind(this)
   }
-  if (enable_editing) {
-    utils.extend(keys, {
-      build_mode: {
-        key: 'n',
-        target: this,
-        fn: this.build_mode,
-        ignore_with_input: true,
-      },
-      zoom_mode: {
-        key: 'z',
-        target: this,
-        fn: this.zoom_mode,
-        ignore_with_input: true,
-      },
-      brush_mode: {
-        key: 'v',
-        target: this,
-        fn: this.brush_mode,
-        ignore_with_input: true,
-      },
-      rotate_mode: {
-        key: 'r',
-        target: this,
-        fn: this.rotate_mode,
-        ignore_with_input: true,
-      },
-      text_mode: {
-        key: 't',
-        target: this,
-        fn: this.text_mode,
-        ignore_with_input: true,
-      },
-      toggle_beziers: {
-        key: 'b',
-        target: map,
-        fn: map.toggle_beziers,
-        ignore_with_input: true,
-      },
-      delete_ctrl: {
-        key: 'ctrl+backspace',
-        target: map,
-        fn: map.delete_selected,
-        ignore_with_input: true,
-      },
-      delete: {
-        key: 'backspace',
-        target: map,
-        fn: map.delete_selected,
-        ignore_with_input: true,
-      },
-      delete_del: {
-        key: 'del',
-        target: map,
-        fn: map.delete_selected,
-        ignore_with_input: true,
-      },
-      toggle_primary: {
-        key: 'p',
-        target: map,
-        fn: map.toggle_selected_node_primary,
-        ignore_with_input: true,
-      },
-      cycle_primary: {
-        key: 'c',
-        target: map,
-        fn: map.cycle_primary_node,
-        ignore_with_input: true,
-      },
-      direction_arrow_right: {
-        key: 'right',
-        target: this.build_input.direction_arrow,
-        fn: this.build_input.direction_arrow.right,
-        ignore_with_input: true,
-      },
-      direction_arrow_down: {
-        key: 'down',
-        target: this.build_input.direction_arrow,
-        fn: this.build_input.direction_arrow.down,
-        ignore_with_input: true,
-      },
-      direction_arrow_left: {
-        key: 'left',
-        target: this.build_input.direction_arrow,
-        fn: this.build_input.direction_arrow.left,
-        ignore_with_input: true,
-      },
-      direction_arrow_up: {
-        key: 'up',
-        target: this.build_input.direction_arrow,
-        fn: this.build_input.direction_arrow.up,
-        ignore_with_input: true,
-      },
-      undo: {
-        key: 'ctrl+z',
-        target: map.undo_stack,
-        fn: map.undo_stack.undo,
-      },
-      redo: {
-        key: 'ctrl+shift+z',
-        target: map.undo_stack,
-        fn: map.undo_stack.redo,
-      },
-      select_all: {
-        key: 'ctrl+a',
-        target: map,
-        fn: map.select_all,
-      },
-      select_none: {
-        key: 'ctrl+shift+a',
-        target: map,
-        fn: map.select_none,
-      },
-      invert_selection: {
-        target: map,
-        fn: map.invert_selection,
-      },
-    })
-  }
-  return keys
 }
 
-/**
- * Ask if the user wants to exit the page (to avoid unplanned refresh).
- */
-function _setup_confirm_before_exit () {
-  window.onbeforeunload = function (e) {
-    // If we haven't been passed the event get the window.event
-    e = e || window.event
-    return  (this.options.never_ask_before_quit ? null :
-             'You will lose any unsaved changes.')
-  }.bind(this)
-}
+export default utils.class_with_optional_new(Builder)

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,7 @@
 
 module.exports = {
   version: ESCHER_VERSION,
-  Builder: require('./Builder'),
+  Builder: require('./Builder').default,
   Map: require('./Map'),
   Behavior: require('./Behavior'),
   KeyManager: require('./KeyManager'),

--- a/src/tests/test_Builder.js
+++ b/src/tests/test_Builder.js
@@ -1,4 +1,4 @@
-const Builder = require('../Builder')
+const Builder = require('../Builder').default
 
 const d3_body = require('./helpers/d3_body')
 

--- a/src/tests/test_utils.js
+++ b/src/tests/test_utils.js
@@ -152,6 +152,25 @@ describe('utils.make_class', () => {
   })
 })
 
+describe('utils.class_with_optional_new', () => {
+  it('takes existing class and makes "new" optional', () => {
+    class C {
+      constructor (a) {
+        this.a = a
+      }
+    }
+    const MyClass = utils.class_with_optional_new(C)
+    const obj1 = new MyClass('b')
+    const obj2 = MyClass('b')
+    const obj3 = new MyClass // eslint-disable-line new-parens
+    assert.isTrue(obj1 instanceof MyClass)
+    assert.isTrue(obj2 instanceof MyClass)
+    assert.isTrue(obj3 instanceof MyClass)
+    assert.strictEqual(obj1.a, 'b')
+    assert.strictEqual(obj2.a, 'b')
+  })
+})
+
 it('utils.compare_arrays', () => {
   assert.strictEqual(utils.compare_arrays([1,2], [1,2]), true)
   assert.strictEqual(utils.compare_arrays([1,2], [3,2]), false)

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,7 @@ module.exports = {
   load_files: load_files,
   load_the_file: load_the_file,
   make_class: make_class,
+  class_with_optional_new: class_with_optional_new,
   setup_defs: setup_defs,
   draw_an_object: draw_an_object,
   draw_a_nested_object: draw_a_nested_object,
@@ -65,7 +66,6 @@ module.exports = {
   d3_transform_catch: d3_transform_catch,
   check_browser: check_browser
 }
-
 
 /**
  * Check if Blob is available, and alert if it is not.
@@ -226,6 +226,17 @@ function make_class () {
   return constructor
 }
 
+/**
+ * Return a class that can be instantiated without the new keyword.
+ * @param {Class} AClass - Any ES6 class.
+ */
+function class_with_optional_new (AClass) {
+  return new Proxy(AClass, {
+    apply (Target, thisArg, args) {
+      return new Target(...args)
+    }
+  })
+}
 
 function setup_defs(svg, style) {
   // add stylesheet

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,7 +288,31 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.25.0, babel-core@^6.26.0:
+babel-core@^6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-generator "^6.25.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.25.0"
+    babel-traverse "^6.25.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
+    convert-source-map "^1.1.0"
+    debug "^2.1.1"
+    json5 "^0.5.0"
+    lodash "^4.2.0"
+    minimatch "^3.0.2"
+    path-is-absolute "^1.0.0"
+    private "^0.1.6"
+    slash "^1.0.0"
+    source-map "^0.5.0"
+
+babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -673,14 +697,21 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.16.0, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -690,7 +721,17 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-template@^6.24.1:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.25.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
+    lodash "^4.2.0"
+
+babel-traverse@^6.18.0, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -704,7 +745,21 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-traverse@^6.24.1:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+babel-types@^6.18.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -712,6 +767,15 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babel-types@^6.19.0, babel-types@^6.24.1:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -1242,8 +1306,8 @@ cookie@0.3.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
 core-js@^2.4.0, core-js@^2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.0.tgz#569c050918be6486b3837552028ae0466b717086"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -4256,8 +4320,8 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 private@^0.1.6, private@^0.1.7:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -4861,7 +4925,13 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
-source-map-support@^0.4.15, source-map-support@^0.4.6:
+source-map-support@^0.4.15:
+  version "0.4.16"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.16.tgz#16fecf98212467d017d586a2af68d628b9421cd8"
+  dependencies:
+    source-map "^0.5.6"
+
+source-map-support@^0.4.6:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:


### PR DESCRIPTION
Switch Builder to use ES6 classes. Also include a new fallback function `utils.class_with_optional_new` so that the Builder class can still be instantiated without the `new` keyword. The could be deprecated eventually, but it would be a breaking change.