### PR TITLE
Use ES6 for main.js

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -30,9 +30,24 @@ Or, if you use NPM, you can simply install `escher`::
 
   npm install --save escher
 
+Or with yarn::
+
+  yarn add escher
+
 For an example of the boilerplate code that is required to begin developing with
 Escher, have a look at the `escher-demo repository`_. For projects built with
 npm, use the `escher-test repository`_ as a guide.
+
+Import Escher
+=============
+
+The Escher JavaScript file uses UMD_, so you can include it in almost any project.
+
+If you are using JavaScript ES6 import syntax, the default export is Builder::
+
+  import Builder from 'escher'
+  import * as escher from 'escher'
+  console.log(Builder, escher.Builder, escher.libs.preact)
 
 Building and testing Escher
 ===========================
@@ -145,3 +160,4 @@ than what is provided in the documentation, please contact Zachary King
 .. _SchemaVer: http://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/
 .. _`core metabolism map`: https://raw.githubusercontent.com/escher/escher.github.io/master/1-0-0/maps/Escherichia%20coli/E%20coli%20core.Core%20metabolism.json
 .. _`core metabolism model`: https://raw.githubusercontent.com/escher/escher.github.io/master/1-0-0/models/Escherichia%20coli/E%20coli%20core.json
+.. _UMD: https://github.com/umdjs/umd

--- a/src/main.js
+++ b/src/main.js
@@ -52,7 +52,6 @@ export { default as utils } from './utils'
 export { default as SearchIndex } from './SearchIndex'
 export { default as Settings } from './Settings'
 export { default as data_styles } from './data_styles'
-export { default as ui } from './ui'
 export { default as escherStatic } from './static'
 export { default as ZoomContainer } from './ZoomContainer'
 

--- a/src/main.js
+++ b/src/main.js
@@ -31,30 +31,39 @@
 // ESCHER_VERSION provided by webpack plugin or main-node
 /* global ESCHER_VERSION */
 
-module.exports = {
-  version: ESCHER_VERSION,
-  Builder: require('./Builder').default,
-  Map: require('./Map'),
-  Behavior: require('./Behavior'),
-  KeyManager: require('./KeyManager'),
-  DataMenu: require('./DataMenu'),
-  UndoStack: require('./UndoStack'),
-  CobraModel: require('./CobraModel'),
-  utils: require('./utils'),
-  SearchIndex: require('./SearchIndex'),
-  Settings: require('./Settings'),
-  data_styles: require('./data_styles'),
-  static: require('./static'),
-  ZoomContainer: require('./ZoomContainer'),
-  libs: {
-    '_': require('underscore'),
-    'underscore': require('underscore'),
-    'preact': require('preact'),
-    'baconjs': require('baconjs'),
-    'mousetrap': require('mousetrap'),
-    'vkbeautify': require('vkbeautify'),
-    'd3_selection': require('d3-selection'),
-    'd3_select': require('d3-selection').select,
-    'd3_json': require('d3-request').json
-  }
+import underscore from 'underscore'
+import preact from 'preact'
+import baconjs from 'baconjs'
+import mousetrap from 'mousetrap'
+import vkbeautify from 'vkbeautify'
+import { select as d3_select, selection as d3_selection } from 'd3-selection'
+import { json as d3_json } from 'd3-request'
+
+export const version = ESCHER_VERSION
+
+export { default as Builder, default } from './Builder'
+export { default as Map } from './Map'
+export { default as Behavior } from './Behavior'
+export { default as KeyManager } from './KeyManager'
+export { default as DataMenu } from './DataMenu'
+export { default as UndoStack } from './UndoStack'
+export { default as CobraModel } from './CobraModel'
+export { default as utils } from './utils'
+export { default as SearchIndex } from './SearchIndex'
+export { default as Settings } from './Settings'
+export { default as data_styles } from './data_styles'
+export { default as ui } from './ui'
+export { default as escherStatic } from './static'
+export { default as ZoomContainer } from './ZoomContainer'
+
+export const libs = {
+  _: underscore,
+  underscore,
+  preact,
+  baconjs,
+  mousetrap,
+  vkbeautify,
+  d3_selection,
+  d3_select,
+  d3_json
 }

--- a/src/tests/test_main.js
+++ b/src/tests/test_main.js
@@ -1,13 +1,45 @@
-var escher = require('../main');
+import Builder, * as escher from '../main'
 
-var describe = require('mocha').describe;
-var it = require('mocha').it;
-var assert = require('chai').assert;
+import {describe, it} from 'mocha'
+import {assert} from 'chai'
 
+describe('main', () => {
+  it('properties', () => {
+    const properties = [
+      'version', 'Builder', 'Map', 'Behavior', 'KeyManager', 'DataMenu',
+      'UndoStack', 'CobraModel', 'utils', 'SearchIndex', 'Settings',
+      'data_styles', 'escherStatic', 'ZoomContainer'
+    ]
+    properties.map(property => {
+      assert.property(escher, property)
+    })
+  })
 
-describe('main', function() {
-    it('version', function () {
-        assert.property(escher, 'version');
-        assert.property(escher, 'Builder');
-    });
-});
+  it('libs', () => {
+    const libs = [
+      '_', 'underscore', 'preact', 'baconjs', 'mousetrap', 'vkbeautify',
+      'd3_selection', 'd3_select', 'd3_json'
+    ]
+    libs.map(lib => {
+      assert.property(escher.libs, lib)
+    })
+  })
+
+  it('Builder with or without new', () => {
+    const builder1 = new Builder(null, null, null, null, {})
+    const builder2 = Builder(null, null, null, null, {})
+    const builder3 = new escher.Builder(null, null, null, null, {})
+    assert(builder1 instanceof Builder)
+    assert(builder2 instanceof Builder)
+    assert(builder3 instanceof Builder)
+  })
+
+  it('old style class', () => {
+    const settings = new escher.Settings(() => {}, () => {}, [])
+    assert(settings instanceof escher.Settings)
+  })
+
+  it('old style collection', () => {
+    assert.property(escher.utils, 'set_options')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,7 +284,7 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
+babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -684,7 +684,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.16.0, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -694,7 +694,17 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-template@^6.24.1:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.25.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
+    lodash "^4.2.0"
+
+babel-traverse@^6.18.0, babel-traverse@^6.25.0, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -708,7 +718,21 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-traverse@^6.24.1:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+babel-types@^6.18.0, babel-types@^6.25.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -717,7 +741,16 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@^6.18.0:
+babel-types@^6.19.0, babel-types@^6.24.1:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babylon@^6.17.2, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -1447,9 +1480,9 @@ d3-array@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
 
-d3-brush@zakandrewking/d3-brush:
+"d3-brush@https://github.com/zakandrewking/d3-brush.git":
   version "1.0.4"
-  resolved "https://codeload.github.com/zakandrewking/d3-brush/tar.gz/0def381d33b6de58383c6f8df68f042b690df416"
+  resolved "https://github.com/zakandrewking/d3-brush.git#0def381d33b6de58383c6f8df68f042b690df416"
   dependencies:
     d3-dispatch "1"
     d3-drag "1"
@@ -2466,7 +2499,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.14.0, globals@^9.18.0:
+globals@^9.0.0, globals@^9.14.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -3297,7 +3330,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -5275,7 +5308,7 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
-to-fast-properties@^1.0.3:
+to-fast-properties@^1.0.1, to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 


### PR DESCRIPTION
The ES6 exports are now standardized and documented. The proper way to import Escher is:

```
import Builder from 'escher'
import * as escher from 'escher'
console.log(Builder, escher.Builder, escher.libs.preact)
```