### PR TITLE
Issue fixes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": [ [ "es2015", { "loose": true } ] ],
+  "presets": [ [ "babel-preset-env", { "loose": true } ] ],
   "plugins": [
     "transform-object-rest-spread",
     [ "transform-react-jsx", { "pragma": "h" } ]

--- a/dev-server/index.js
+++ b/dev-server/index.js
@@ -1,7 +1,7 @@
 import map from '../docs/_static/example_data/S5_iJO1366.Glycolysis_PPP_AA_Nucleotides.json'
 import { Builder, libs } from '../src/main'
 
-new Builder( // eslint-disable-line no-new
+window.builder = new Builder( // eslint-disable-line no-new
   map,
   null,
   null,

--- a/package.json
+++ b/package.json
@@ -28,10 +28,9 @@
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.1",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-register": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
     "bootswatch": "^3.3.6",
     "chai": "^3.3.0",
     "coveralls": "^3.0.0",

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -130,7 +130,7 @@ class Builder {
       allow_building_duplicate_reactions: false,
       cofactors: [
         'atp', 'adp', 'nad', 'nadh', 'nadp', 'nadph', 'gtp', 'gdp', 'h', 'coa',
-        'ump', 'h20', 'ppi'
+        'ump', 'h2o', 'ppi'
       ],
       // Extensions
       tooltip_component: DefaultTooltip,

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -535,12 +535,13 @@ class Builder {
     }
   }
 
-  renderSearchBar (hide) {
+  renderSearchBar (hide, searchItem) {
     if (!this.options.enable_search) { return }
     const searchBarNode = this.search_bar_div.node()
     preact.render(
       <SearchBar
         visible={!hide}
+        searchItem={searchItem}
         searchIndex={this.map.search_index}
         map={this.map}
         ref={instance => { this.searchBarRef = instance }}

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -12,7 +12,7 @@ class SearchBar extends Component {
     this.state = {
       visible: props.visible,
       current: 0,
-      searchItem: null,
+      searchItem: props.searchItem,
       counter: '',
       clearEscape: this.props.map.key_manager.add_escape_listener(
         () => this.close(), true
@@ -29,7 +29,7 @@ class SearchBar extends Component {
       ...nextProps,
       current: 0,
       results: null,
-      searchItem: null,
+      searchItem: nextProps.searchItem,
       counter: '',
       clearEscape: this.props.map.key_manager.add_escape_listener(
         () => this.close(), true
@@ -39,6 +39,9 @@ class SearchBar extends Component {
       clearPrevious: this.props.map.key_manager.add_key_listener(
         ['shift+enter', 'shift+ctrl+g'], () => this.previous(), false)
     })
+    if (nextProps.searchItem !== null) {
+      this.handleInput(nextProps.searchItem)
+    }
   }
 
   componentDidUpdate () {

--- a/src/ZoomContainer.js
+++ b/src/ZoomContainer.js
@@ -422,12 +422,8 @@ function zoom_out () {
  * @returns {Object} The size coordinates, e.g. { x: 2, y: 3 }.
  */
 function get_size () {
-  var width = parseInt(this.selection.style('width'), 10)
-  var height = parseInt(this.selection.style('height'), 10)
-  if (_.isNaN(width) || _.isNaN(height)) {
-    throw new Error('Size not defined for ZoomContainer element.')
-  }
-  return { width: width, height: height }
+  const {width, height} = this.selection.node().getBoundingClientRect()
+  return { width, height }
 }
 
 /**

--- a/src/tests/test_Builder.js
+++ b/src/tests/test_Builder.js
@@ -13,7 +13,21 @@ const mocha = require('mocha')
 const assert = require('assert')
 
 function make_parent_sel (s) {
-  return s.append('div').style('width', '100px').style('height', '100px')
+  var element = s.append('div');
+  const width = 100;
+  const height = 100;
+  // Workaround to be able to use getBoundingClientRect
+  // which always returns {height: 0, width: 0, ...} in jsdom.
+  // https://github.com/jsdom/jsdom/issues/653#issuecomment-266749765
+  element.node().getBoundingClientRect = () => ({
+    width,
+    height,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+  });
+  return element;
 }
 
 describe('Builder', () => {

--- a/src/tests/test_ZoomContainer.js
+++ b/src/tests/test_ZoomContainer.js
@@ -46,20 +46,6 @@ describe('ZoomContainer', () => {
                        zc.zoomed_sel.node())
   })
 
-  it('get_size, defined', () => {
-    const sel2 = sel.style('width', '100px').style('height', '100px')
-    const zc = ZoomContainer(sel2, 'none', true, true)
-    const res = zc.get_size()
-    assert.deepEqual(res, { width: 100, height: 100 })
-  })
-
-  it('get_size, undefined', () => {
-    const zc = ZoomContainer(sel, 'none', true, true)
-    assert.throws(() => {
-      zc.get_size()
-    }, /Size not defined for ZoomContainer element/)
-  }).timeout(20000)
-
   it('go_to -- no d3 transform', (done) => {
     // no d3 transform
     const zc = ZoomContainer(sel, 'none', false, true)

--- a/src/utils.js
+++ b/src/utils.js
@@ -871,15 +871,15 @@ function distance (start, end) {
  * "arguments" from any function and an array of argument names.
  */
 function check_undefined (args, names) {
-  names.map(function (name, i) {
+  names.forEach(function (name, i) {
     if (args[i] === undefined) {
-      console.error('Argument is undefined: ' + String(names[i]))
+      console.error(`Argument is undefined: ${names[i]}`)
     }
   })
 }
 
 function compartmentalize (bigg_id, compartment_id) {
-  return bigg_id + '_' + compartment_id
+  return `${bigg_id}_${compartment_id}`;
 }
 
 /**


### PR DESCRIPTION
- Use babel-preset-env https://github.com/zakandrewking/escher/issues/240
- Pre-fill search bar
We needed this functionality - we wanted to programmatically pre-fill the search bar, this way we could traverse the occurrences of genes.
- Assign builder to window in dev server envrionment
Just a convenience trick, this way the builder is easily accessible as `window.builder`
- Use forEach instead of map in utils. check_undefined
I was looking at the performance on our platform and realized that quite some time is spent on this function. I did a bit of a performance testing and on my computer [this test](https://gist.github.com/matyasfodor/a2c30ebcc5f526517f88c415459c9e4c) resulted in a 7x speedup. So I switched to forEach.
- h20 -> h2o fixes https://github.com/zakandrewking/escher/issues/189
- ZoomContainer get_size issue fixes https://github.com/zakandrewking/escher/issues/188
I think this is the proper way of getting the element size as explained in [here](https://stackoverflow.com/questions/21990857/d3-js-how-to-get-the-computed-width-and-height-for-an-arbitrary-element/21991405#21991405)