### PR TITLE
New Feature: User defined showing of tooltips

### DIFF
--- a/docs/javascript_api.rst
+++ b/docs/javascript_api.rst
@@ -308,8 +308,12 @@ JavaScript API
 
        .. js:attribute:: options.enable_tooltips
 
-          (Default: ``true``) If true, then show tooltips when hoving over
-          reactions, metabolites, and genes.
+          (Default: `[`label`]`) Determines the mouseover or touch event required 
+          to show the related tooltip.['label'] will show tooltips upon mouseover 
+          or touch of the reaction or metabolite labels whereas ['object'] will 
+          show the the tooltips over the reaction line segments and metabolite 
+          circles. Can be set as an empty array to disable tooltips or can have 
+          both options passed in to enable tooltips over both labels and objects.
 
        **Callbacks**
 

--- a/src/Behavior.js
+++ b/src/Behavior.js
@@ -13,6 +13,8 @@
  * my_behavior.bezier_drag,
  * my_behavior.bezier_mouseover, my_behavior.bezier_mouseout,
  * my_behavior.reaction_label_drag, my_behavior.node_label_drag,
+ * my_behavior.object_mouseover, my_behavior.object_touch, 
+ * my_behavior.object_mouseout
  *
  */
 
@@ -37,6 +39,8 @@ Behavior.prototype = {
   toggle_label_drag: toggle_label_drag,
   toggle_label_mouseover: toggle_label_mouseover,
   toggle_label_touch: toggle_label_touch,
+  toggle_object_mouseover: toggle_object_mouseover,
+  toggle_object_touch: toggle_object_touch,
   toggle_bezier_drag: toggle_bezier_drag,
   // util
   turn_off_drag: turn_off_drag,
@@ -74,6 +78,9 @@ function init (map, undo_stack) {
   this.label_mouseover = null
   this.label_mouseout = null
   this.label_touch = null
+  this.object_mouseover = null
+  this.object_touch = null
+  this.object_mouseout = null
   this.bezier_drag = this.empty_behavior
   this.bezier_mouseover = null
   this.bezier_mouseout = null
@@ -92,6 +99,8 @@ function turn_everything_on () {
   this.toggle_label_drag(true)
   this.toggle_label_mouseover(true)
   this.toggle_label_touch(true)
+  this.toggle_object_mouseover(true)
+  this.toggle_object_touch(true)
 }
 
 /**
@@ -103,6 +112,8 @@ function turn_everything_off () {
   this.toggle_label_drag(false)
   this.toggle_label_mouseover(false)
   this.toggle_label_touch(false)
+  this.toggle_object_mouseover(false)
+  this.toggle_object_touch(false)
 }
 
 /**
@@ -413,6 +424,9 @@ function toggle_label_touch (on_off) {
   }
 
   if (on_off) {
+    // Show/hide tooltip.
+    // @param {String} type - 'reaction_label' or 'node_label'
+    // @param {Object} d - D3 data for DOM element
     this.label_touch = (type, d) => {
       if (!this.dragging) {
         this.map.callback_manager.run('show_tooltip', null, type, d)
@@ -420,6 +434,55 @@ function toggle_label_touch (on_off) {
     }
   } else {
     this.label_touch = null
+  }
+}
+
+/**
+ * With no argument, toggle the tooltips on mouseover of nodes or arrows.
+ * @param {Boolean} on_off - The new on/off state.
+ */
+function toggle_object_mouseover (on_off) {
+  if (on_off === undefined) {
+    on_off = this.label_mouseover === null
+  }
+
+  if (on_off) {
+
+    // Show/hide tooltip.
+    // @param {String} type - 'reaction_object' or 'node_object'
+    // @param {Object} d - D3 data for DOM element
+    this.object_mouseover = function (type, d) {
+      if (!this.dragging) {
+        this.map.callback_manager.run('show_tooltip', null, type, d)
+      }
+    }.bind(this)
+
+    this.object_mouseout = function () {
+      this.map.callback_manager.run('delay_hide_tooltip')
+    }.bind(this)
+
+  } else {
+    this.object_mouseover = null
+  }
+}
+
+/**
+ * With no argument, toggle the tooltips upon touching of nodes or arrows.
+ * @param {Boolean} on_off - The new on/off state. If this argument is not provided, then toggle the state.
+ */
+function toggle_object_touch (on_off) {
+  if (on_off === undefined) {
+    on_off = this.label_touch === null
+  }
+
+  if (on_off) {
+    this.object_touch = (type, d) => {
+      if (!this.dragging) {
+        this.map.callback_manager.run('show_tooltip', null, type, d)
+      }
+    }
+  } else {
+    this.object_touch = null
   }
 }
 

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -134,7 +134,7 @@ class Builder {
       ],
       // Extensions
       tooltip_component: DefaultTooltip,
-      enable_tooltips: true,
+      enable_tooltips: ['labels'],
       reaction_scale_preset: null,
       metabolite_scale_preset: null,
       // Callbacks

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -134,7 +134,7 @@ class Builder {
       ],
       // Extensions
       tooltip_component: DefaultTooltip,
-      enable_tooltips: ['labels'],
+      enable_tooltips: ['label'],
       reaction_scale_preset: null,
       metabolite_scale_preset: null,
       // Callbacks

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -134,7 +134,7 @@ class Builder {
       ],
       // Extensions
       tooltip_component: DefaultTooltip,
-      enable_tooltips: ['label'],
+      enable_tooltips: ['label', 'object'],
       reaction_scale_preset: null,
       metabolite_scale_preset: null,
       // Callbacks

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -134,7 +134,7 @@ class Builder {
       ],
       // Extensions
       tooltip_component: DefaultTooltip,
-      enable_tooltips: ['label', 'object'],
+      enable_tooltips: ['label'],
       reaction_scale_preset: null,
       metabolite_scale_preset: null,
       // Callbacks

--- a/src/BuilderSettingsMenu.css
+++ b/src/BuilderSettingsMenu.css
@@ -113,7 +113,7 @@
   margin-right: 10px
 }
 
-.escher-container .radioSelection .singleLine {
+.escher-container .settingsBox .singleLine {
   display: flex;
 }
 
@@ -193,4 +193,8 @@
 .escher-container .settingsBox .icon-sort-down {
   position: absolute;
   top: 0;
+}
+
+.escher-container .settingsBox .tooltipOption {
+  margin-left: 10px;
 }

--- a/src/BuilderSettingsMenu.js
+++ b/src/BuilderSettingsMenu.js
@@ -227,18 +227,45 @@ class BuilderSettingsMenu extends Component {
                   checked={this.props.highlight_missing}
                 />Highlight reactions not in model
               </label>
-              <label title='Show tooltips when hovering over reactions, metabolites, and genes'>
-                <input
-                  type='checkbox'
-                  onClick={() =>
-                    this.props.settings.set_conditional(
-                      'enable_tooltips', !this.props.enable_tooltips
-                    )
-                  }
-                  checked={this.props.enable_tooltips}
-                  />
-                  Show tooltips
-              </label>
+              <table>
+                <tr title='Determines over which elements tooltips will display for reactions, metabolites, and genes'>
+                  <td>
+                      Show tooltips over:
+                  </td>
+                  <td className='singleLine' >
+                    <label className='tooltipOption' title='If checked, tooltips will display over the gene, reaction, and metabolite labels'>
+                      <input
+                        type='checkbox'
+                        onClick={() =>
+                          this.props.settings.set_conditional(
+                            'enable_tooltips',
+                            this.props.enable_tooltips.indexOf('label') > -1
+                              ? update(this.props.enable_tooltips, {$splice: [[this.props.enable_tooltips.indexOf('label'), 1]]})
+                              : update(this.props.enable_tooltips, {$push: ['label']})
+                          )
+                        }
+                        checked={this.props.enable_tooltips.indexOf('label') > -1}
+                        />
+                      Labels
+                    </label>
+                    <label className='tooltipOption' title='If checked, tooltips will display over the reaction line segments and metabolite circles'>
+                      <input
+                        type='checkbox'
+                        onClick={() =>
+                          this.props.settings.set_conditional(
+                            'enable_tooltips',
+                            this.props.enable_tooltips.indexOf('object') > -1
+                              ? update(this.props.enable_tooltips, {$splice: [[this.props.enable_tooltips.indexOf('object'), 1]]})
+                              : update(this.props.enable_tooltips, {$push: ['object']})
+                          )
+                        }
+                        checked={this.props.enable_tooltips.indexOf('object') > -1}
+                        />
+                      Objects
+                    </label>
+                  </td>
+                </tr>
+              </table>
             </div>
             <div className='settingsTip' style={{marginTop: '16px'}}>
               <i>Tip: To increase map performance, turn off text boxes (i.e. labels and gene reaction rules).</i>

--- a/src/BuilderSettingsMenu.js
+++ b/src/BuilderSettingsMenu.js
@@ -464,6 +464,10 @@ class BuilderSettingsMenu extends Component {
               stats={this.props.map.get_data_statistics().metabolite}
               noDataColor={this.props.metabolite_no_data_color}
               noDataSize={this.props.metabolite_no_data_size}
+              onChange={(scale) => {
+                this.props.settings.set_conditional('metabolite_scale', scale)
+              }}
+              abs={this.props.metabolite_styles.indexOf('abs') > -1}
             />
             <div className='subheading'>
               Metabolite data

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -327,6 +327,9 @@ function update_segment (update_selection, scale, cobra_model,
   var hide_secondary_metabolites = this.settings.get_option('hide_secondary_metabolites')
   var primary_r = this.settings.get_option('primary_metabolite_radius')
   var secondary_r = this.settings.get_option('secondary_metabolite_radius')
+  var object_mouseover_fn = this.behavior.object_mouseover
+  var object_mouseout_fn = this.behavior.object_mouseout
+  var object_touch_fn = this.behavior.object_touch
   var get_arrow_size = function (data, should_size) {
     var width = 20
     var height = 13
@@ -417,6 +420,13 @@ function update_segment (update_selection, scale, cobra_model,
       } else {
         return null
       }
+    })
+    .attr('pointer-events', 'visibleStroke')
+    .on('mouseover', function (d) {
+      object_mouseover_fn('reaction_object', d)
+    })
+    .on('touchend', function (d) {
+      object_touch_fn('reaction_object', d)
     })
 
   // new arrowheads
@@ -745,6 +755,9 @@ function update_node (update_selection, scale, has_data_on_nodes,
   var label_mouseover_fn = this.behavior.label_mouseover
   var label_mouseout_fn = this.behavior.label_mouseout
   var label_touch_fn = this.behavior.label_touch
+  var object_mouseover_fn = this.behavior.object_mouseover
+  var object_mouseout_fn = this.behavior.object_mouseout
+  var object_touch_fn = this.behavior.object_touch
 
   var mg = update_selection
       .select('.node-circle')
@@ -786,8 +799,13 @@ function update_node (update_selection, scale, has_data_on_nodes,
     .call(drag_behavior)
     .on('mousedown', mousedown_fn)
     .on('click', click_fn)
-    .on('mouseover', mouseover_fn)
+    .on('mouseover', function (d) {
+      object_mouseover_fn('node_object', d)
+    })
     .on('mouseout', mouseout_fn)
+    .on('touchend', function (d) {
+      object_touch_fn('node_object', d)
+    })
 
   // update node label visibility
   var node_label = update_selection

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -426,15 +426,17 @@ function update_segment (update_selection, scale, cobra_model,
     })
     .attr('pointer-events', 'visibleStroke')
     .on('mouseover', function (d) {
+      const mouseEvent = d3_mouse(this)
       // Add the current mouse position to the segment's datum
       object_mouseover_fn('reaction_object', Object.assign(
-        {}, d, {xPos: d3_mouse(this)[0], yPos: d3_mouse(this)[1]}
+        {}, d, {xPos: mouseEvent[0], yPos: mouseEvent[1]}
       ))
     })
     .on('touchend', function (d) {
+      const touchEvent = d3_touch(this.parentNode, 0)
       // Add last touch position to the segment's datum
       object_touch_fn('reaction_object', Object.assign(
-        {}, d, {xPos: d3_touch(this.parentNode, 0)[0], yPos: d3_touch(this.parentNode, 0)[1]}
+        {}, d, {xPos: touchEvent[0], yPos: touchEvent[1]}
       ))
     })
     .on('mouseout', object_mouseout_fn)
@@ -813,16 +815,18 @@ function update_node (update_selection, scale, has_data_on_nodes,
     .on('mousedown', mousedown_fn)
     .on('click', click_fn)
     .on('mouseover', function (d) {
+      const mouseEvent = d3_mouse(this.parentNode)
       // Add current mouse position to the node's datum
       object_mouseover_fn('node_object', Object.assign(
-        {}, d, {xPos: d3_mouse(this.parentNode)[0], yPos: d3_mouse(this.parentNode)[1]}
+        {}, d, {xPos: mouseEvent[0], yPos: mouseEvent[1]}
       ))
     })
     .on('mouseout', object_mouseout_fn)
     .on('touchend', function (d) {
+      touchEvent = d3_touch(this.parentNode, 0)
       // Add the touch position to the node's datum
       object_touch_fn('node_object', Object.assign(
-        {}, d, {xPos: d3_touch(this.parentNode, 0)[0], yPos: d3_touch(this.parentNode, 0)[1]}
+        {}, d, {xPos: touchEvent[0], yPos: touchEvent[1]}
       ))
     })
     .call(sel => {

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -433,9 +433,9 @@ function update_segment (update_selection, scale, cobra_model,
     })
     .on('touchend', function (d) {
       // Add last touch position to the segment's datum
-      object_touch_fn('reaction_object', function () {
-        Object.assign({}, d, {xPos: d3_touch(this)[0], yPos: d3_touch(this)[1]}
-      )})
+      object_touch_fn('reaction_object', Object.assign(
+        {}, d, {xPos: d3_touch(this.parentNode, 0)[0], yPos: d3_touch(this.parentNode, 0)[1]}
+      ))
     })
     .on('mouseout', object_mouseout_fn)
     .call(sel => {
@@ -813,19 +813,17 @@ function update_node (update_selection, scale, has_data_on_nodes,
     .on('mousedown', mousedown_fn)
     .on('click', click_fn)
     .on('mouseover', function (d) {
-      console.log(d3_mouse(this))
       // Add current mouse position to the node's datum
-      object_mouseover_fn('reaction_object', Object.assign(
-        {}, d, {xPos: d3_mouse(this)[0], yPos: d3_mouse(this)[1]}
+      object_mouseover_fn('node_object', Object.assign(
+        {}, d, {xPos: d3_mouse(this.parentNode)[0], yPos: d3_mouse(this.parentNode)[1]}
       ))
     })
     .on('mouseout', object_mouseout_fn)
     .on('touchend', function (d) {
-      console.log(d3_touch(this))
       // Add the touch position to the node's datum
-      object_touch_fn('node_object', function () {
-        Object.assign({}, d, {xPos: d3_touch(this)[0], yPos: d3_touch(this)[1]}
-      )})
+      object_touch_fn('node_object', Object.assign(
+        {}, d, {xPos: d3_touch(this.parentNode, 0)[0], yPos: d3_touch(this.parentNode, 0)[1]}
+      ))
     })
     .call(sel => {
       this.map.callback_manager.run('update_tooltip', null, 'node_label', sel)

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -814,6 +814,9 @@ function update_node (update_selection, scale, has_data_on_nodes,
         label_mouseover_fn('node_label', d)
       })
       .on('mouseout', label_mouseout_fn)
+      .call(sel => {
+        this.map.callback_manager.run('update_tooltip', null, 'node_label', sel)
+      })
   }
 
   this.callback_manager.run('update_node', this, update_selection)

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -33,6 +33,8 @@ var data_styles = require('./data_styles')
 var CallbackManager = require('./CallbackManager')
 var d3_format = require('d3-format').format
 var d3_select = require('d3-selection').select
+var d3_mouse = require('d3-selection').mouse
+var d3_touch = require('d3-selection').touch
 
 var Draw = utils.make_class()
 // instance methods
@@ -426,19 +428,14 @@ function update_segment (update_selection, scale, cobra_model,
     .on('mouseover', function (d) {
       // Add the current mouse position to the segment's datum
       object_mouseover_fn('reaction_object', Object.assign(
-        {}, d, {xPos: event.clientX, yPos: event.clientY}
+        {}, d, {xPos: d3_mouse(this)[0], yPos: d3_mouse(this)[1]}
       ))
     })
     .on('touchend', function (d) {
       // Add last touch position to the segment's datum
-      object_touch_fn('reaction_object', Object.assign(
-        {}, 
-        d, 
-        {
-          xPos: event.changedTouches[0].clientX, 
-          yPos: event.changedTouches[0].clientY
-        }
-      ))
+      object_touch_fn('reaction_object', function () {
+        Object.assign({}, d, {xPos: d3_touch(this)[0], yPos: d3_touch(this)[1]}
+      )})
     })
     .on('mouseout', object_mouseout_fn)
     .call(sel => {
@@ -816,22 +813,19 @@ function update_node (update_selection, scale, has_data_on_nodes,
     .on('mousedown', mousedown_fn)
     .on('click', click_fn)
     .on('mouseover', function (d) {
+      console.log(d3_mouse(this))
       // Add current mouse position to the node's datum
-      object_mouseover_fn('node_object', Object.assign(
-        {}, d, {xPos: event.clientX, yPos: event.clientY}
+      object_mouseover_fn('reaction_object', Object.assign(
+        {}, d, {xPos: d3_mouse(this)[0], yPos: d3_mouse(this)[1]}
       ))
     })
     .on('mouseout', object_mouseout_fn)
     .on('touchend', function (d) {
+      console.log(d3_touch(this))
       // Add the touch position to the node's datum
-      object_touch_fn('node_object', Object.assign(
-        {}, 
-        d, 
-        {
-          xPos: event.changedTouches[0].clientX, 
-          yPos: event.changedTouches[0].clientY
-        }
-      ))
+      object_touch_fn('node_object', function () {
+        Object.assign({}, d, {xPos: d3_touch(this)[0], yPos: d3_touch(this)[1]}
+      )})
     })
     .call(sel => {
       this.map.callback_manager.run('update_tooltip', null, 'node_label', sel)

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -175,7 +175,7 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
   var label_mouseover_fn = this.behavior.label_mouseover
   var label_mouseout_fn = this.behavior.label_mouseout
   var label_touch_fn = this.behavior.label_touch
-
+  
   // label location
   update_selection
     .attr('transform', function(d) {
@@ -354,7 +354,8 @@ function update_segment (update_selection, scale, cobra_model,
   update_selection
     .selectAll('.segment')
     .datum(function () {
-      return this.parentNode.__data__
+      // Concatenate the segment data with the reaction data from its parent node
+      return Object.assign({}, this.parentNode.__data__, this.parentNode.parentNode.__data__)
     })
     .style('visibility', function(d) {
       var start = drawn_nodes[d.from_node_id]

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -428,6 +428,10 @@ function update_segment (update_selection, scale, cobra_model,
     .on('touchend', function (d) {
       object_touch_fn('reaction_object', d)
     })
+    .on('mouseout', object_mouseout_fn)
+    .call(sel => {
+      this.map.callback_manager.run('update_tooltip', null, 'reaction_label', sel)
+    })
 
   // new arrowheads
   var arrowheads = update_selection.select('.arrowheads')
@@ -802,9 +806,12 @@ function update_node (update_selection, scale, has_data_on_nodes,
     .on('mouseover', function (d) {
       object_mouseover_fn('node_object', d)
     })
-    .on('mouseout', mouseout_fn)
+    .on('mouseout', object_mouseout_fn)
     .on('touchend', function (d) {
       object_touch_fn('node_object', d)
+    })
+    .call(sel => {
+      this.map.callback_manager.run('update_tooltip', null, 'node_label', sel)
     })
 
   // update node label visibility

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -424,10 +424,21 @@ function update_segment (update_selection, scale, cobra_model,
     })
     .attr('pointer-events', 'visibleStroke')
     .on('mouseover', function (d) {
-      object_mouseover_fn('reaction_object', d)
+      // Add the current mouse position to the segment's datum
+      object_mouseover_fn('reaction_object', Object.assign(
+        {}, d, {xPos: event.clientX, yPos: event.clientY}
+      ))
     })
     .on('touchend', function (d) {
-      object_touch_fn('reaction_object', d)
+      // Add last touch position to the segment's datum
+      object_touch_fn('reaction_object', Object.assign(
+        {}, 
+        d, 
+        {
+          xPos: event.changedTouches[0].clientX, 
+          yPos: event.changedTouches[0].clientY
+        }
+      ))
     })
     .on('mouseout', object_mouseout_fn)
     .call(sel => {
@@ -805,11 +816,22 @@ function update_node (update_selection, scale, has_data_on_nodes,
     .on('mousedown', mousedown_fn)
     .on('click', click_fn)
     .on('mouseover', function (d) {
-      object_mouseover_fn('node_object', d)
+      // Add current mouse position to the node's datum
+      object_mouseover_fn('node_object', Object.assign(
+        {}, d, {xPos: event.clientX, yPos: event.clientY}
+      ))
     })
     .on('mouseout', object_mouseout_fn)
     .on('touchend', function (d) {
-      object_touch_fn('node_object', d)
+      // Add the touch position to the node's datum
+      object_touch_fn('node_object', Object.assign(
+        {}, 
+        d, 
+        {
+          xPos: event.changedTouches[0].clientX, 
+          yPos: event.changedTouches[0].clientY
+        }
+      ))
     })
     .call(sel => {
       this.map.callback_manager.run('update_tooltip', null, 'node_label', sel)

--- a/src/Dropdown.css
+++ b/src/Dropdown.css
@@ -79,7 +79,7 @@
 
   .escher-container .dropdownButton {
     padding: 6px 10px;
-    padding-right: 18px;
+    padding-right: 16px;
   }
 
   .escher-container .helpButton {

--- a/src/TooltipContainer.js
+++ b/src/TooltipContainer.js
@@ -67,7 +67,10 @@ function setup_map_callbacks (map) {
 
   //
   map.callback_manager.set('show_tooltip.tooltip_container', function (type, d) {
-    if (map.settings.get_option('enable_tooltips')) {
+    if (map.settings.get_option('enable_tooltips').toString().includes(type
+      .replace('reaction_', '')
+      .replace('node_', '')
+      .replace('gene_', ''))) {
       this.show(type, d)
     }
   }.bind(this))
@@ -135,7 +138,7 @@ function show (type, d) {
     const offset = {x: 0, y: 0}
     const rightEdge = windowScale * d.label_x + windowTranslate.x + tooltipSize.width
     const bottomEdge = windowScale * d.label_y + windowTranslate.y + tooltipSize.height
-    console.log({labelX: d.label_x, labelY: d.label_y, mouseX: d.xPos, mouseY: d.yPos})
+    // console.log({labelX: d.label_x, labelY: d.label_y, mouseX: d.xPos, mouseY: d.yPos})
     if (mapSize.width < 500) {
       if (rightEdge > mapSize.width) {
         offset.x = -(rightEdge - mapSize.width) / windowScale

--- a/src/TooltipContainer.js
+++ b/src/TooltipContainer.js
@@ -120,11 +120,11 @@ function is_visible () {
  * @param {Object} d - D3 data for DOM element
  */
 function show (type, d) {
-  console.log(type)
+  console.log(type, d)
   // get rid of a lingering delayed hide
   this.cancelHideTooltip()
 
-  if (_.contains([ 'reaction_label', 'node_label', 'gene_label' ], type)) {
+  if (_.contains([ 'reaction_label', 'node_label', 'gene_label', 'reaction_object', 'node_object' ], type)) {
     // Use a default height if the ref hasn't been connected yet
     const tooltipSize = (this.tooltipRef !== null && this.tooltipRef.getSize)
     ? this.tooltipRef.getSize()
@@ -162,7 +162,7 @@ function show (type, d) {
       name: d.name,
       loc: coords,
       data: d.data_string,
-      type: type.replace('_label', '').replace('node', 'metabolite')
+      type: type.replace('_label', '').replace('node', 'metabolite').replace('_object', '')
     }
     this.callback_manager.run('setState', null, data)
   } else {

--- a/src/TooltipContainer.js
+++ b/src/TooltipContainer.js
@@ -78,7 +78,7 @@ function setup_map_callbacks (map) {
 
   //
   map.callback_manager.set('hide_tooltip.tooltip_container', this.hide.bind(this))
-  map.sel.selectAll('#canvas').on('touchend', this.hide.bind(this))
+  map.sel.selectAll('.canvas-group').on('touchend', this.hide.bind(this))
   map.callback_manager.set('delay_hide_tooltip.tooltip_container', this.delay_hide.bind(this))
   map.callback_manager.set('update_tooltip.tooltip_container', (type, sel) => {
     if (this.currentTooltip !== null) {

--- a/src/TooltipContainer.js
+++ b/src/TooltipContainer.js
@@ -67,6 +67,7 @@ function setup_map_callbacks (map) {
 
   //
   map.callback_manager.set('show_tooltip.tooltip_container', function (type, d) {
+    // Check if the current element is in the list of tooltips to display
     if (map.settings.get_option('enable_tooltips').indexOf(type
       .replace('reaction_', '')
       .replace('node_', '')
@@ -131,14 +132,19 @@ function show (type, d) {
     const tooltipSize = (this.tooltipRef !== null && this.tooltipRef.getSize)
     ? this.tooltipRef.getSize()
     : { width: 270, height: 100 }
-    this.currentTooltip = { type, id: d[type.replace('_label', '_id')] }
+    this.currentTooltip = { type, id: d[type.replace('_label', '_id').replace('_object', '_id')] }
     const windowTranslate = this.zoom_container.window_translate
     const windowScale = this.zoom_container.window_scale
     const mapSize = this.map !== null ? this.map.get_size() : { width: 1000, height: 1000 }
     const offset = {x: 0, y: 0}
-    const rightEdge = windowScale * d.label_x + windowTranslate.x + tooltipSize.width
-    const bottomEdge = windowScale * d.label_y + windowTranslate.y + tooltipSize.height
-    // console.log({labelX: d.label_x, labelY: d.label_y, mouseX: d.xPos, mouseY: d.yPos})
+    const startPosX = (type.replace('reaction_', '').replace('node_', '').replace('gene_', '') === 'object')
+      ? d.xPos
+      : d.label_x
+    const startPosY = (type.replace('reaction_', '').replace('node_', '').replace('gene_', '') === 'object')
+      ? d.yPos
+      : d.label_y
+    const rightEdge = windowScale * startPosX + windowTranslate.x + tooltipSize.width
+    const bottomEdge = windowScale * startPosY + windowTranslate.y + tooltipSize.height
     if (mapSize.width < 500) {
       if (rightEdge > mapSize.width) {
         offset.x = -(rightEdge - mapSize.width) / windowScale
@@ -147,18 +153,18 @@ function show (type, d) {
         offset.y = -(bottomEdge - mapSize.height + 77) / windowScale
       }
     } else {
-      if (windowScale * d.label_x + windowTranslate.x + 0.5 * tooltipSize.width > mapSize.width) {
+      if (windowScale * startPosX + windowTranslate.x + 0.5 * tooltipSize.width > mapSize.width) {
         offset.x = -tooltipSize.width / windowScale
       } else if (rightEdge > mapSize.width) {
         offset.x = -(rightEdge - mapSize.width) / windowScale
       }
-      if (windowScale * d.label_y + windowTranslate.y + 0.5 * tooltipSize.height > mapSize.height - 45) {
+      if (windowScale * startPosY + windowTranslate.y + 0.5 * tooltipSize.height > mapSize.height - 45) {
         offset.y = -(tooltipSize.height) / windowScale
       } else if (bottomEdge > mapSize.height - 45) {
         offset.y = -(bottomEdge - mapSize.height + 47) / windowScale
       }
     }
-    const coords = { x: d.label_x + offset.x, y: d.label_y + 10 + offset.y }
+    const coords = { x: startPosX + offset.x, y: startPosY + 10 + offset.y }
     this.placed_div.place(coords)
     const data = {
       biggId: d.bigg_id,

--- a/src/TooltipContainer.js
+++ b/src/TooltipContainer.js
@@ -120,7 +120,6 @@ function is_visible () {
  * @param {Object} d - D3 data for DOM element
  */
 function show (type, d) {
-  console.log(type, d)
   // get rid of a lingering delayed hide
   this.cancelHideTooltip()
 
@@ -136,6 +135,7 @@ function show (type, d) {
     const offset = {x: 0, y: 0}
     const rightEdge = windowScale * d.label_x + windowTranslate.x + tooltipSize.width
     const bottomEdge = windowScale * d.label_y + windowTranslate.y + tooltipSize.height
+    console.log({labelX: d.label_x, labelY: d.label_y, mouseX: d.xPos, mouseY: d.yPos})
     if (mapSize.width < 500) {
       if (rightEdge > mapSize.width) {
         offset.x = -(rightEdge - mapSize.width) / windowScale

--- a/src/TooltipContainer.js
+++ b/src/TooltipContainer.js
@@ -67,10 +67,10 @@ function setup_map_callbacks (map) {
 
   //
   map.callback_manager.set('show_tooltip.tooltip_container', function (type, d) {
-    if (map.settings.get_option('enable_tooltips').toString().includes(type
+    if (map.settings.get_option('enable_tooltips').indexOf(type
       .replace('reaction_', '')
       .replace('node_', '')
-      .replace('gene_', ''))) {
+      .replace('gene_', '')) > -1) {
       this.show(type, d)
     }
   }.bind(this))

--- a/src/TooltipContainer.js
+++ b/src/TooltipContainer.js
@@ -120,6 +120,7 @@ function is_visible () {
  * @param {Object} d - D3 data for DOM element
  */
 function show (type, d) {
+  console.log(type)
   // get rid of a lingering delayed hide
   this.cancelHideTooltip()
 

--- a/src/TooltipContainer.js
+++ b/src/TooltipContainer.js
@@ -78,6 +78,7 @@ function setup_map_callbacks (map) {
 
   //
   map.callback_manager.set('hide_tooltip.tooltip_container', this.hide.bind(this))
+  // Hides the tooltip when the canvas is touched
   map.sel.selectAll('.canvas-group').on('touchend', this.hide.bind(this))
   map.callback_manager.set('delay_hide_tooltip.tooltip_container', this.delay_hide.bind(this))
   map.callback_manager.set('update_tooltip.tooltip_container', (type, sel) => {


### PR DESCRIPTION
Adds the option for users to define whether to display tooltips over node/metabolite labels or objects (line segments or node circles). enable_tooltips now accepts an array containing either 'object', 'label', both, or neither. Includes the necessary changes to BuilderSettingsMenu.js and API documentation. Also fixes a previously unnoticed regression where touching the canvas wouldn't hide the active tooltip.