### PR TITLE
fix: fixes both issues #257 and #259

### DIFF
--- a/src/Draw.js
+++ b/src/Draw.js
@@ -815,19 +815,23 @@ function update_node (update_selection, scale, has_data_on_nodes,
     .on('mousedown', mousedown_fn)
     .on('click', click_fn)
     .on('mouseover', function (d) {
-      const mouseEvent = d3_mouse(this.parentNode)
-      // Add current mouse position to the node's datum
-      object_mouseover_fn('node_object', Object.assign(
-        {}, d, {xPos: mouseEvent[0], yPos: mouseEvent[1]}
-      ))
+      if (d.node_type === 'metabolite') {
+        const mouseEvent = d3_mouse(this.parentNode)
+        // Add current mouse position to the node's datum
+        object_mouseover_fn('node_object', Object.assign(
+          {}, d, {xPos: mouseEvent[0], yPos: mouseEvent[1]}
+        ))
+      }
     })
     .on('mouseout', object_mouseout_fn)
     .on('touchend', function (d) {
-      touchEvent = d3_touch(this.parentNode, 0)
-      // Add the touch position to the node's datum
-      object_touch_fn('node_object', Object.assign(
-        {}, d, {xPos: touchEvent[0], yPos: touchEvent[1]}
-      ))
+      if (d.node_type === 'metabolite') {
+        touchEvent = d3_touch(this.parentNode, 0)
+        // Add the touch position to the node's datum
+        object_touch_fn('node_object', Object.assign(
+          {}, d, {xPos: touchEvent[0], yPos: touchEvent[1]}
+        ))
+      }
     })
     .call(sel => {
       this.map.callback_manager.run('update_tooltip', null, 'node_label', sel)

--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -24,7 +24,7 @@ class MenuButton extends Component {
   handleFileInput (file) {
     const reader = new window.FileReader()
     if (file.name.split('.').pop().toLowerCase() === 'json' || 'csv') {
-      reader.onload = (event) => {
+      reader.onload = () => {
         utils.load_json_or_csv(file, dataStyles.csv_converter, (e, d) => this.props.onClick(d))
       } 
     } else {

--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -10,6 +10,8 @@
 /** @jsx h */
 import { h, Component } from 'preact'
 import * as _ from 'underscore'
+import utils from './utils.js'
+import dataStyles from './data_styles.js'
 
 class MenuButton extends Component {
   constructor (props) {
@@ -22,25 +24,10 @@ class MenuButton extends Component {
   //  TODO: Differentiate parsing between allowable file types instead of just JSON Issue #257
   handleFileInput (file) {
     const reader = new window.FileReader()
-    if (file.name.split('.').pop().toLowerCase() === 'json') {
+    if (file.name.split('.').pop().toLowerCase() === 'json' || 'csv') {
       reader.onload = (event) => {
-        this.props.onClick(JSON.parse(event.target.result))
-      }
-    } else if (file.name.split('.').pop().toLowerCase() === 'csv') {
-      reader.onload = (event) => {
-        const arr = event.target.result.split('/n')
-        const headers = arr[0].split(',')
-        const jsonObj = []
-        for(let i = 1; i < arr.length; i++) {
-          const data = arr[i].split(',')
-          let obj = {}
-          for(let j = 0; j < data.length; j++) {
-            obj[headers[j].trim()] = data[j].trim()
-          }
-          jsonObj.push(obj)
-        }
-        this.props.onClick(JSON.stringify(jsonObj))
-      }
+        utils.load_json_or_csv(file, dataStyles.csv_converter, (e, d) => this.props.onClick(d))
+      } 
     } else {
       console.warn('Unrecognized file format')
     }

--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -21,7 +21,6 @@ class MenuButton extends Component {
     }
   }
 
-  //  TODO: Differentiate parsing between allowable file types instead of just JSON Issue #257
   handleFileInput (file) {
     const reader = new window.FileReader()
     if (file.name.split('.').pop().toLowerCase() === 'json' || 'csv') {

--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -19,10 +19,30 @@ class MenuButton extends Component {
     }
   }
 
+  //  TODO: Differentiate parsing between allowable file types instead of just JSON Issue #257
   handleFileInput (file) {
     const reader = new window.FileReader()
-    reader.onload = (event) => {
-      this.props.onClick(JSON.parse(event.target.result))
+    if (file.name.split('.').pop().toLowerCase() === 'json') {
+      reader.onload = (event) => {
+        this.props.onClick(JSON.parse(event.target.result))
+      }
+    } else if (file.name.split('.').pop().toLowerCase() === 'csv') {
+      reader.onload = (event) => {
+        const arr = event.target.result.split('/n')
+        const headers = arr[0].split(',')
+        const jsonObj = []
+        for(let i = 1; i < arr.length; i++) {
+          const data = arr[i].split(',')
+          let obj = {}
+          for(let j = 0; j < data.length; j++) {
+            obj[headers[j].trim()] = data[j].trim()
+          }
+          jsonObj.push(obj)
+        }
+        this.props.onClick(JSON.stringify(jsonObj))
+      }
+    } else {
+      console.warn('Unrecognized file format')
     }
     if (file !== undefined) {
       reader.readAsText(file)

--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -23,12 +23,8 @@ class MenuButton extends Component {
 
   handleFileInput (file) {
     const reader = new window.FileReader()
-    if (file.name.split('.').pop().toLowerCase() === 'json' || 'csv') {
-      reader.onload = () => {
-        utils.load_json_or_csv(file, dataStyles.csv_converter, (e, d) => this.props.onClick(d))
-      } 
-    } else {
-      console.warn('Unrecognized file format')
+    reader.onload = () => {
+      utils.load_json_or_csv(file, dataStyles.csv_converter, (e, d) => this.props.onClick(d))
     }
     if (file !== undefined) {
       reader.readAsText(file)


### PR DESCRIPTION
Restricts Draw.js to only call the mouseover and touch callbacks on metabolite type node-circles. Also adds a function within MenuButton.js to parse CSV files and load them.