### PR TITLE
Deprecate full_screen_button option and optimize full screen button & keys

### DIFF
--- a/docs/javascript_api.rst
+++ b/docs/javascript_api.rst
@@ -81,8 +81,8 @@ JavaScript API
 
        .. js:attribute:: options.full_screen_button
 
-          (Default: ``false``) Include a button in the user interface for
-          entering full screen mode.
+          DEPRECATED. Full screen button always appears, so this option is no
+          longer necessary.
 
        .. js:attribute:: options.ignore_bootstrap
 

--- a/src/BuildInput.js
+++ b/src/BuildInput.js
@@ -53,8 +53,8 @@ function init (selection, map, zoom_container, settings) {
   d3_select(c.input)
   this.completely = c
   // close button
-  new_sel.append('button').attr('class', 'button input-close-button')
-    .text("×")
+  new_sel.append('button').attr('class', 'btn input-close-button')
+    .text('×')
     .on('mousedown', function () { this.hide_dropdown() }.bind(this))
 
   // map

--- a/src/Builder.css
+++ b/src/Builder.css
@@ -391,6 +391,13 @@ resizes. */
   background-image: linear-gradient(#4F5151, #474949 6%, #3F4141);
   background-color: white;
   cursor: pointer;
+  border-radius: 4px;
+  font-size: 14px!important;
+  font-weight: 400;
+  width: 40px;
+  height: 40px;
+  text-align: center;
+  padding: 0;
 }
 
 .escher-container .btn:active {

--- a/src/BuilderMenuBar.jsx
+++ b/src/BuilderMenuBar.jsx
@@ -210,6 +210,11 @@ class BuilderMenuBar extends Component {
             disabledButtons={this.props.disabled_buttons}
           />
           <MenuButton
+            name={'Toggle full screen' + (this.props.enable_keys ? ' (Ctrl+2)' : '')}
+            onClick={() => this.props.toggleFullScreen()}
+            disabledButtons={this.props.disabled_buttons}
+          />
+          <MenuButton
             name={'Find' + (this.props.enable_keys ? ' (F)' : '')}
             onClick={() => this.props.search()}
             disabledButtons={this.props.disabled_buttons}

--- a/src/ButtonPanel.css
+++ b/src/ButtonPanel.css
@@ -22,58 +22,37 @@
 
 .escher-container .buttonGroup {
   display: block;
-  margin-bottom: -1px;
   padding: 5px 0px;
   border-radius: 0;
 }
 
-.escher-container .grouping>.buttonGroup:first-child {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-}
-
-.escher-container .grouping>.buttonGroup:last-child {
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
-}
-
-.escher-container .buttonPanel>.grouping:last-child {
-  margin-top: 4px;
-}
-
-.escher-container #currentMode {
-  background-image: linear-gradient(#8F4F3F,#834c3c 6%,#8d3a2d);
-}
-
 .escher-container .buttonGroup.btn {
-  margin-top: -1px;
-}
-
-.escher-container .button {
-  border-radius: 4px;
-}
-
-.escher-container .button.btn, .escher-container .buttonGroup.btn {
-  padding: unset;
-  color: white!important;
-  border: 1px solid #474949;
-  background-image: linear-gradient(#4F5151, #474949 6%, #3F4141);
-  background-color: white;
-  text-align: center;
+  border-radius: unset;
   vertical-align: middle;
-  cursor: pointer;
-  font-size: 14px!important;
-  font-weight: 400;
   width: 40px;
   height: 40px;
 }
 
-.escher-container .buttonPanel .button:active, .escher-container .buttonGroup label:active, .escher-container .buttonPanel .buttonGroup:active {
-  background-image: linear-gradient(#3F4141, #474949 6%, #4F5151);
+.escher-container .grouping>.buttonGroup:first-child {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}
+
+.escher-container .grouping>.buttonGroup:last-child {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+
+.escher-container .buttonPanel>.grouping:last-child {
+    margin-top: 4px;
 }
 
 .escher-container .buttonPanel .fa {
   font-size: 24px;
+}
+
+.escher-container #current-mode, .escher-container .active-button {
+    background-image: linear-gradient(#8F4F3F,#834c3c 6%,#8d3a2d) !important;
 }
 
 /* Icons */

--- a/src/ButtonPanel.jsx
+++ b/src/ButtonPanel.jsx
@@ -8,49 +8,47 @@ import './ButtonPanel.css'
  * porting Builder to Preact
  */
 class ButtonPanel extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      isFullScreen: false
+    }
+  }
+
   render () {
     return (
       <ul className='buttonPanel'>
-        <li>
+        <li className='grouping'>
           <button
-            className='button btn'
+            className='buttonGroup btn'
             onClick={() => this.props.zoomContainer.zoom_in()}
             title='Zoom in (+)'
           >
             <i className='icon-zoom-in' />
           </button>
-        </li>
-        <li>
           <button
-            className='button btn'
+            className='buttonGroup btn'
             onClick={() => this.props.zoomContainer.zoom_out()}
             title='Zoom out (-)'
           >
             <i className='icon-zoom-out' />
           </button>
-        </li>
-        <li
-          style={this.props.all
-          ? {display: 'block'}
-          : {display: 'none'}}
-        >
           <button
-            className='button btn'
-            onClick={() => this.props.map.zoom_extent_canvas()}
+            className='buttonGroup btn'
+            onClick={() => this.props.zoomExtentCanvas()}
             title='Zoom to canvas (1)'
           >
             <i className='icon-resize-full' />
           </button>
         </li>
-        <li
-          style={this.props.fullscreen
-          ? {display: 'block'}
-          : {display: 'none'}}
-        >
+        <li>
           <button
-            className='button btn'
-            onClick={() => this.props.map.full_screen()}
-            title='Toggle full screen view (2)'
+            className={this.state.isFullScreen ? 'btn active-button' : 'btn'}
+            onClick={() => {
+              this.props.toggleFullScreen()
+              this.setState({isFullScreen: !this.state.isFullScreen})
+            }}
+            title='Toggle full screen (Ctrl+2)'
           >
             <i className='icon-resize-full-alt' />
           </button>
@@ -65,7 +63,7 @@ class ButtonPanel extends Component {
             className='buttonGroup btn'
             title='Pan mode (Z)'
             for='zoom'
-            id={this.props.mode === 'zoom' ? 'currentMode' : null}
+            id={this.props.mode === 'zoom' ? 'current-mode' : null}
             onClick={() => this.props.setMode('zoom')}
           >
             <i className='icon-move' />
@@ -74,7 +72,7 @@ class ButtonPanel extends Component {
             className='buttonGroup btn'
             title='Select mode (V)'
             for='brush'
-            id={this.props.mode === 'brush' ? 'currentMode' : null}
+            id={this.props.mode === 'brush' ? 'current-mode' : null}
             onClick={() => this.props.setMode('brush')}
           >
             <i className='icon-mouse-pointer' />
@@ -84,14 +82,14 @@ class ButtonPanel extends Component {
             title='Add reaction mode (N)'
             for='build'
             onClick={() => this.props.setMode('build')}
-            id={this.props.mode === 'build' ? 'currentMode' : null}>
+            id={this.props.mode === 'build' ? 'current-mode' : null}>
             <i className='icon-wrench' />
           </button>
           <button
             className='buttonGroup btn'
             title='Rotate mode (R)'
             for='rotate'
-            id={this.props.mode === 'rotate' ? 'currentMode' : null}
+            id={this.props.mode === 'rotate' ? 'current-mode' : null}
             onClick={() => this.props.setMode('rotate')}
           >
             <i className='icon-cw' />
@@ -100,7 +98,7 @@ class ButtonPanel extends Component {
             className='buttonGroup btn'
             title='Text mode (T)'
             for='text'
-            id={this.props.mode === 'text' ? 'currentMode' : null}
+            id={this.props.mode === 'text' ? 'current-mode' : null}
             onClick={() => this.props.setMode('text')}
           >
             <i className='icon-font' />

--- a/src/Map.js
+++ b/src/Map.js
@@ -152,10 +152,6 @@ Map.prototype = {
   highlight_node: highlight_node,
   highlight_text_label: highlight_text_label,
   highlight: highlight,
-  // full screen
-  listen_for_full_screen: listen_for_full_screen,
-  unlisten_for_full_screen: unlisten_for_full_screen,
-  full_screen: full_screen,
   // io
   save: save,
   map_for_export: map_for_export,
@@ -280,13 +276,6 @@ function init (svg, css, selection, zoom_container, settings, cobra_model,
 
   // rotation mode off
   this.rotation_on = false
-
-  // set up full screen listener
-  this.listen_for_full_screen(function () {
-    setTimeout(function() {
-      this.zoom_extent_canvas()
-    }.bind(this), 50)
-  }.bind(this))
 }
 
 // -------------------------------------------------------------------------
@@ -2111,67 +2100,9 @@ function highlight (sel) {
   }
 }
 
-// -------------------------------------------------------------------------
-// Full screen
-// -------------------------------------------------------------------------
-
-function full_screen_event () {
-  if      (document.fullscreenEnabled)       return 'fullscreenchange'
-  else if (document.mozFullScreenEnabled)    return 'mozfullscreenchange'
-  else if (document.webkitFullscreenEnabled) return 'webkitfullscreenchange'
-  else if (document.msFullscreenEnabled)     return 'MSFullscreenChange'
-  else                                       return null
-}
-
-/**
- * Call the function when full screen is enabled.
- *
- * To unregister the event listener for the full screen event,
- * unlisten_for_full_screen.
- */
-function listen_for_full_screen (fn) {
-  document.addEventListener(full_screen_event(), fn)
-  this.full_screen_listener = fn
-}
-
-/**
- * Remove the listener created by listen_for_full_screen.
- */
-function unlisten_for_full_screen () {
-  document.removeEventListener(full_screen_event(), this.full_screen_listener)
-}
-
-/**
- * Enter full screen if supported by the browser.
- */
-function full_screen () {
-  var sel = this.zoom_container.selection
-  var e = sel.node()
-  var d = document
-  var full_screen_on = (d.fullscreenElement || d.mozFullScreenElement ||
-                        d.webkitFullscreenElement || d.msFullscreenElement)
-  if (full_screen_on) {
-    // apply full heigh/width 100%
-    sel.classed('full-screen-on', false)
-    // exit
-    if      (d.exitFullscreen)       d.exitFullscreen()
-    else if (d.mozCancelFullScreen)  d.mozCancelFullScreen()
-    else if (d.webkitExitFullscreen) d.webkitExitFullscreen()
-    else if (d.msExitFullscreen)     d.msExitFullscreen()
-    else throw Error('Cannot exit full screen')
-  } else {
-    sel.classed('full-screen-on', true)
-    // enter
-    if      (e.requestFullscreen)       e.requestFullscreen()
-    else if (e.mozRequestFullScreen)    e.mozRequestFullScreen()
-    else if (e.webkitRequestFullscreen) e.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT)
-    else if (e.msRequestFullscreen)     e.msRequestFullscreen()
-    else throw Error('Full screen does not seem to be supported on this system.')
-  }
-}
-
-// -------------------------------------------------------------------------
+// --
 // IO
+// --
 
 function save () {
   utils.download_json(this.map_for_export(), this.map_name)


### PR DESCRIPTION
- The button to toggle full screen now appears no matter what; the option has
  been deprecated
- The toggle full-screen functionality appears in the View menu
- The keyboard shorcut for toggling full screen is just Ctrl-2 (and not "2")
- Cleaned up button grouping in the button bar
- Clean up button CSS classes

TODO reactively render fullscreen state by passing props in a function