### PR TITLE
Performance improvements for pan & zoom

### DIFF
--- a/dev-server/index.js
+++ b/dev-server/index.js
@@ -1,5 +1,5 @@
-import map from '../docs/_static/example_data/S5_iJO1366.Glycolysis_PPP_AA_Nucleotides.json'
-import model from '../docs/_static/example_data/iJO1366.json'
+import map from '/Users/zaking/repos/escher.github.io/1-0-0/6/maps/Homo sapiens/RECON1.Amino acid metabolism (partial).json'
+import model from '/Users/zaking/repos/escher.github.io/1-0-0/6/models/Homo sapiens/RECON1.json'
 import { Builder, libs } from '../src/main'
 
 window.builder = new Builder( // eslint-disable-line no-new

--- a/dev-server/index.js
+++ b/dev-server/index.js
@@ -1,5 +1,5 @@
-import map from '/Users/zaking/repos/escher.github.io/1-0-0/6/maps/Homo sapiens/RECON1.Amino acid metabolism (partial).json'
-import model from '/Users/zaking/repos/escher.github.io/1-0-0/6/models/Homo sapiens/RECON1.json'
+import map from '../docs/_static/example_data/S5_iJO1366.Glycolysis_PPP_AA_Nucleotides.json'
+import model from '../docs/_static/example_data/iJO1366.json'
 import { Builder, libs } from '../src/main'
 
 window.builder = new Builder( // eslint-disable-line no-new

--- a/docs/tips-and-tricks.rst
+++ b/docs/tips-and-tricks.rst
@@ -52,3 +52,23 @@ other subsystems.
 
 .. _escher.github.io: https://www.github.com/escher/escher.github.io/
 .. _`BiGG Database`: http://bigg.ucsd.edu
+
+Escher performance with large maps
+----------------------------------
+
+Escher works best with maps that have less than about 200 reactions. If you are
+working with more reactions, we recommend splitting your map into multiple small
+maps. A trick for splitting up a map is to first select the reactions you want
+to keep, then choose "Edit > Invert Selection" and then "Edit > Delete".
+
+If you really want to work with larger maps, the following can help improve
+performance:
+
+- Turn off tooltips in the settings menu, especially tooltips over Objects
+- Try the "Use 3D Transform" option in the settings menu. Depending on your
+  browser, this can increase responsiveness when moving around the map.
+- Turn off labels, gene reaction rules, and/or secondary metabolites in the
+  settings menu.
+
+We are always trying to make Escher faster, so let us know if you find any
+unexpected performance issues.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "d3-request": "^1.0.3",
     "d3-scale": "^1.0.4",
     "d3-selection": "^1.0.3",
-    "d3-zoom": "^1.1.1",
+    "d3-zoom": "^1.7.3",
     "file-saver": "^1.3.3",
     "immutability-helper": "^2.4.0",
     "mousetrap": "^1.5.3",

--- a/src/Behavior.js
+++ b/src/Behavior.js
@@ -29,47 +29,23 @@ export default class Behavior {
     this.textLabelMousedown = null
     this.textLabelClick = null
     this.selectableDrag = this.emptyBehavior
-    this.nodeMouseover = null
-    this.nodeMouseout = null
-    this.labelMouseover = this.emptyBehavior
-    this.labelMouseout = null
-    this.labelTouch = null
-    this.objectMouseover = this.emptyBehavior
-    this.objectTouch = null
-    this.objectMouseout = null
+
+    this.nodeLabelMouseover = null
+    this.nodeLabelTouch = null
+    this.nodeLabelMouseout = null
+    this.reactionLabelMouseover = null
+    this.reactionLabelTouch = null
+    this.reactionLabelMouseout = null
+    this.geneLabelMouseover = null
+    this.geneLabelTouch = null
+    this.geneLabelMouseout = null
+
     this.bezierDrag = this.emptyBehavior
     this.bezierMouseover = null
     this.bezierMouseout = null
     this.reactionLabelDrag = this.emptyBehavior
     this.nodeLabelDrag = this.emptyBehavior
     this.dragging = false
-    this.turnEverythingOn()
-  }
-
-  /**
-   * Toggle everything except rotation mode and text mode.
-   */
-  turnEverythingOn () {
-    this.toggleSelectableClick(true)
-    this.toggleSelectableDrag(true)
-    this.toggleLabelDrag(true)
-    this.toggleLabelMouseover(true)
-    this.toggleLabelTouch(true)
-    this.toggleObjectMouseover(true)
-    this.toggleObjectTouch(true)
-  }
-
-  /**
-   * Toggle everything except rotation mode and text mode.
-   */
-  turnEverythingOff () {
-    this.toggleSelectableClick(false)
-    this.toggleSelectableDrag(false)
-    this.toggleLabelDrag(false)
-    this.toggleLabelMouseover(false)
-    this.toggleLabelTouch(false)
-    this.toggleObjectMouseover(false)
-    this.toggleObjectTouch(false)
   }
 
   averageLocation (nodes) {
@@ -344,48 +320,40 @@ export default class Behavior {
    */
   toggleLabelMouseover (onOff) {
     if (onOff === undefined) {
-      onOff = this.labelMouseover === this.emptyBehavior
+      onOff = this.nodeLabelMouseover === null
     }
 
     if (onOff) {
       // Show/hide tooltip.
       // @param {String} type - 'reactionLabel' or 'nodeLabel'
       // @param {Object} d - D3 data for DOM element
-      this.labelMouseover = (type, d) => {
+      const getMouseover = type => d => {
         if (!this.dragging) {
           this.map.callback_manager.run('show_tooltip', null, type, d)
         }
       }
-
-      this.labelMouseout = () => {
+      const mouseout = () => {
         this.map.callback_manager.run('delay_hide_tooltip')
       }
+      this.nodeLabelMouseover = getMouseover('node_label')
+      this.nodeLabelTouch = getMouseover('node_label')
+      this.nodeLabelMouseout = mouseout
+      this.reactionLabelMouseover = getMouseover('reaction_label')
+      this.reactionLabelTouch = getMouseover('reaction_label')
+      this.reactionLabelMouseout = mouseout
+      this.geneLabelMouseover = getMouseover('gene_label')
+      this.geneLabelTouch = getMouseover('gene_label')
+      this.geneLabelMouseout = mouseout
     } else {
-      this.labelMouseover = this.emptyBehavior
-    }
-  }
-
-  /**
-   * With no argument, toggle the tooltips upon touching of labels.
-   * @param {Boolean} onOff - The new on/off state. If this argument is not
-   *                          provided, then toggle the state.
-   */
-  toggleLabelTouch (onOff) {
-    if (onOff === undefined) {
-      onOff = this.labelTouch === null
-    }
-
-    if (onOff) {
-      // Show/hide tooltip.
-      // @param {String} type - 'reactionLabel' or 'nodeLabel'
-      // @param {Object} d - D3 data for DOM element
-      this.labelTouch = (type, d) => {
-        if (!this.dragging) {
-          this.map.callback_manager.run('show_tooltip', null, type, d)
-        }
-      }
-    } else {
-      this.labelTouch = null
+      this.nodeLabelMouseover = null
+      this.nodeLabelTouch = null
+      this.nodeLabelMouseout = null
+      this.reactionLabelMouseover = null
+      this.reactionLabelTouch = null
+      this.reactionLabelMouseout = null
+      this.geneLabelMouseover = null
+      this.geneLabelTouch = null
+      this.geneLabelMouseout = null
     }
   }
 
@@ -395,24 +363,34 @@ export default class Behavior {
    */
   toggleObjectMouseover (onOff) {
     if (onOff === undefined) {
-      onOff = this.objectMouseover === this.emptyBehavior
+      onOff = this.nodeObjectMouseover === null
     }
 
     if (onOff) {
       // Show/hide tooltip.
       // @param {String} type - 'reaction_object' or 'node_object'
       // @param {Object} d - D3 data for DOM element
-      this.objectMouseover = (type, d) => {
+      const getMouseover = type => d => {
         if (!this.dragging) {
           this.map.callback_manager.run('show_tooltip', null, type, d)
         }
       }
-
-      this.objectMouseout = () => {
+      const mouseout = () => {
         this.map.callback_manager.run('delay_hide_tooltip')
       }
+      this.nodeObjectMouseover = getMouseover('node_object')
+      this.nodeObjectMouseout = mouseout
+      this.reactionObjectMouseover = getMouseover('reaction_object')
+      this.reactionObjectMouseout = mouseout
+      this.geneObjectMouseover = getMouseover('gene_object')
+      this.geneObjectMouseout = mouseout
     } else {
-      this.objectMouseover = this.emptyBehavior
+      this.nodeObjectMouseover = null
+      this.nodeObjectMouseout = null
+      this.reactionObjectMouseover = null
+      this.reactionObjectMouseout = null
+      this.geneObjectMouseover = null
+      this.geneObjectMouseout = null
     }
   }
 

--- a/src/Behavior.js
+++ b/src/Behavior.js
@@ -31,7 +31,6 @@ export default class Behavior {
     this.selectableDrag = this.emptyBehavior
     this.nodeMouseover = null
     this.nodeMouseout = null
-    this.labelMousedown = null
     this.labelMouseover = this.emptyBehavior
     this.labelMouseout = null
     this.labelTouch = null

--- a/src/Builder.jsx
+++ b/src/Builder.jsx
@@ -244,6 +244,11 @@ class Builder {
       this.zoom_container.setScrollBehavior(val)
     })
 
+    // Reactive tooltip settings
+    this.settings.streams.enable_tooltips.onValue(val => {
+      this._updateTooltipSetting(val)
+    })
+
     // Make a container for other map-related tools that will be reset on map load
     // TODO only create these once in the Builder constructor
     this.mapToolsContainer = this.selection.append('div')
@@ -385,6 +390,9 @@ class Builder {
     // Connect status bar
     this._setupStatus(this.map)
     this.map.set_status('Loading map ...')
+
+    // Connect tooltips
+    this._updateTooltipSetting(this.settings.get('enable_tooltips'))
 
     // Set the data for the map
     if (shouldUpdateData) {
@@ -766,8 +774,6 @@ class Builder {
     }
     this.map.behavior.toggleSelectableClick(mode === 'build' || mode === 'brush') // XX
     this.map.behavior.toggleLabelDrag(mode === 'brush') // XX
-    // this.map.behavior.toggleLabelMouseover(true)
-    // this.map.behavior.toggleLabelTouch(true)
     this.map.behavior.toggleTextLabelEdit(mode === 'text') // XX
     this.map.behavior.toggleBezierDrag(mode === 'brush') // XX
 
@@ -1075,6 +1081,11 @@ class Builder {
 
   _setupStatus (map) {
     map.callback_manager.set('set_status', status => this.status_bar.html(status))
+  }
+
+  _updateTooltipSetting (setting) {
+    this.map.behavior.toggleLabelMouseover(setting && setting.includes('label'))
+    this.map.behavior.toggleObjectMouseover(setting && setting.includes('object'))
   }
 
   /**

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -183,8 +183,8 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
     .attr('transform', function(d) {
       return 'translate(' + d.label_x + ',' + d.label_y + ')'
     })
-    .call(this.behavior.turnOffDrag)
-    .call(this.behavior.reactionLabelDrag)
+    // .call(this.behavior.turnOffDrag)
+    // .call(this.behavior.reactionLabelDrag)
 
   // update label visibility
   var label = update_selection.select('.reaction-label')
@@ -200,14 +200,14 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
         }
         return t
       })
-      .on('mousedown', label_mousedown_fn)
-      .on('mouseover', function (d) {
-        label_mouseover_fn('reaction_label', d)
-      })
-      .on('mouseout', label_mouseout_fn)
-      .on('touchend', function (d) {
-        label_touch_fn('reaction_label', d)
-      })
+      // .on('mousedown', label_mousedown_fn)
+      // .on('mouseover', function (d) {
+      //   label_mouseover_fn('reaction_label', d)
+      // })
+      // .on('mouseout', label_mouseout_fn)
+      // .on('touchend', function (d) {
+      //   label_touch_fn('reaction_label', d)
+      // })
   }
 
   var add_gene_height = function (y, i) {
@@ -254,11 +254,11 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
   gene_g.append('text')
     .attr('class', 'gene-label')
     .style('font-size', gene_font_size + 'px')
-    .on('mousedown', label_mousedown_fn)
-    .on('mouseover', function (d) {
-      label_mouseover_fn('gene_label', d)
-    })
-    .on('mouseout', label_mouseout_fn)
+    // .on('mousedown', label_mousedown_fn)
+    // .on('mouseover', function (d) {
+    //   label_mouseover_fn('gene_label', d)
+    // })
+    // .on('mouseout', label_mouseout_fn)
 
   // update
   var gene_update = gene_g.merge(all_genes_g)
@@ -421,22 +421,22 @@ function update_segment (update_selection, scale, cobra_model,
         return null
       }
     })
-    .attr('pointer-events', 'visibleStroke')
-    .on('mouseover', function (d) {
-      const mouseEvent = d3_mouse(this)
-      // Add the current mouse position to the segment's datum
-      object_mouseover_fn('reaction_object', Object.assign(
-        {}, d, {xPos: mouseEvent[0], yPos: mouseEvent[1]}
-      ))
-    })
-    .on('touchend', function (d) {
-      const touchEvent = d3_touch(this.parentNode, 0)
-      // Add last touch position to the segment's datum
-      object_touch_fn('reaction_object', Object.assign(
-        {}, d, {xPos: touchEvent[0], yPos: touchEvent[1]}
-      ))
-    })
-    .on('mouseout', object_mouseout_fn)
+    // .attr('pointer-events', 'visibleStroke')
+    // .on('mouseover', function (d) {
+    //   const mouseEvent = d3_mouse(this)
+    //   // Add the current mouse position to the segment's datum
+    //   object_mouseover_fn('reaction_object', Object.assign(
+    //     {}, d, {xPos: mouseEvent[0], yPos: mouseEvent[1]}
+    //   ))
+    // })
+    // .on('touchend', function (d) {
+    //   const touchEvent = d3_touch(this.parentNode, 0)
+    //   // Add last touch position to the segment's datum
+    //   object_touch_fn('reaction_object', Object.assign(
+    //     {}, d, {xPos: touchEvent[0], yPos: touchEvent[1]}
+    //   ))
+    // })
+    // .on('mouseout', object_mouseout_fn)
 
   // new arrowheads
   var arrowheads = update_selection.select('.arrowheads')
@@ -674,10 +674,10 @@ function update_bezier(update_selection, show_beziers, drag_behavior,
 
   // Draw bezier points
   update_selection.select('.bezier-circle')
-    .call(this.behavior.turnOffDrag)
-    .call(drag_behavior)
-    .on('mouseover', mouseover)
-    .on('mouseout', mouseout)
+    // .call(this.behavior.turnOffDrag)
+    // .call(drag_behavior)
+    // .on('mouseover', mouseover)
+    // .on('mouseout', mouseout)
     .attr('transform', function (d) {
       if (d.x === null || d.y === null) return ''
       return 'translate(' + d.x + ',' + d.y + ')'
@@ -805,29 +805,29 @@ function update_node (update_selection, scale, has_data_on_nodes,
       // midmarkers and multimarkers
       return null
     })
-    .call(this.behavior.turnOffDrag)
-    .call(drag_behavior)
-    .on('mousedown', mousedown_fn)
-    .on('click', click_fn)
-    .on('mouseover', function (d) {
-      if (d.node_type === 'metabolite') {
-        const mouseEvent = d3_mouse(this.parentNode)
-        // Add current mouse position to the node's datum
-        object_mouseover_fn('node_object', Object.assign(
-          {}, d, {xPos: mouseEvent[0], yPos: mouseEvent[1]}
-        ))
-      }
-    })
-    .on('mouseout', object_mouseout_fn)
-    .on('touchend', function (d) {
-      if (d.node_type === 'metabolite') {
-        touchEvent = d3_touch(this.parentNode, 0)
-        // Add the touch position to the node's datum
-        object_touch_fn('node_object', Object.assign(
-          {}, d, {xPos: touchEvent[0], yPos: touchEvent[1]}
-        ))
-      }
-    })
+    // .call(this.behavior.turnOffDrag)
+    // .call(drag_behavior)
+    // .on('mousedown', mousedown_fn)
+    // .on('click', click_fn)
+    // .on('mouseover', function (d) {
+    //   if (d.node_type === 'metabolite') {
+    //     const mouseEvent = d3_mouse(this.parentNode)
+    //     // Add current mouse position to the node's datum
+    //     object_mouseover_fn('node_object', Object.assign(
+    //       {}, d, {xPos: mouseEvent[0], yPos: mouseEvent[1]}
+    //     ))
+    //   }
+    // })
+    // .on('mouseout', object_mouseout_fn)
+    // .on('touchend', function (d) {
+    //   if (d.node_type === 'metabolite') {
+    //     touchEvent = d3_touch(this.parentNode, 0)
+    //     // Add the touch position to the node's datum
+    //     object_touch_fn('node_object', Object.assign(
+    //       {}, d, {xPos: touchEvent[0], yPos: touchEvent[1]}
+    //     ))
+    //   }
+    // })
 
   // update node label visibility
   var node_label = update_selection
@@ -847,13 +847,13 @@ function update_node (update_selection, scale, has_data_on_nodes,
           t += ' ' + d.data_string
         return t
       })
-      .call(this.behavior.turnOffDrag)
-      .call(label_drag_behavior)
-      .on('mousedown', label_mousedown_fn)
-      .on('mouseover', function (d) {
-        label_mouseover_fn('node_label', d)
-      })
-      .on('mouseout', label_mouseout_fn)
+      // .call(this.behavior.turnOffDrag)
+      // .call(label_drag_behavior)
+      // .on('mousedown', label_mousedown_fn)
+      // .on('mouseover', function (d) {
+      //   label_mouseover_fn('node_label', d)
+      // })
+      // .on('mouseout', label_mouseout_fn)
   }
 
   this.callback_manager.run('update_node', this, update_selection)
@@ -894,10 +894,10 @@ function update_text_label (update_selection) {
     .attr('transform', function (d) {
       return 'translate(' + d.x + ',' + d.y + ')'
     })
-    .on('mousedown', mousedown_fn)
-    .on('click', click_fn)
-    .call(turn_off_drag)
-    .call(drag_behavior)
+    // .on('mousedown', mousedown_fn)
+    // .on('click', click_fn)
+    // .call(turn_off_drag)
+    // .call(drag_behavior)
 
   this.callback_manager.run('update_text_label', this, update_selection)
 }

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -183,8 +183,8 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
     .attr('transform', function(d) {
       return 'translate(' + d.label_x + ',' + d.label_y + ')'
     })
-    // .call(this.behavior.turnOffDrag)
-    // .call(this.behavior.reactionLabelDrag)
+    .call(this.behavior.turnOffDrag)
+    .call(this.behavior.reactionLabelDrag)
 
   // update label visibility
   var label = update_selection.select('.reaction-label')
@@ -674,10 +674,10 @@ function update_bezier(update_selection, show_beziers, drag_behavior,
 
   // Draw bezier points
   update_selection.select('.bezier-circle')
-    // .call(this.behavior.turnOffDrag)
-    // .call(drag_behavior)
-    // .on('mouseover', mouseover)
-    // .on('mouseout', mouseout)
+    .call(this.behavior.turnOffDrag)
+    .call(drag_behavior)
+    .on('mouseover', mouseover)
+    .on('mouseout', mouseout)
     .attr('transform', function (d) {
       if (d.x === null || d.y === null) return ''
       return 'translate(' + d.x + ',' + d.y + ')'
@@ -805,10 +805,10 @@ function update_node (update_selection, scale, has_data_on_nodes,
       // midmarkers and multimarkers
       return null
     })
-    // .call(this.behavior.turnOffDrag)
-    // .call(drag_behavior)
-    // .on('mousedown', mousedown_fn)
-    // .on('click', click_fn)
+    .call(this.behavior.turnOffDrag)
+    .call(drag_behavior)
+    .on('mousedown', mousedown_fn)
+    .on('click', click_fn)
     // .on('mouseover', function (d) {
     //   if (d.node_type === 'metabolite') {
     //     const mouseEvent = d3_mouse(this.parentNode)
@@ -883,10 +883,10 @@ function create_text_label (enter_selection) {
 }
 
 function update_text_label (update_selection) {
-  var mousedown_fn = this.behavior.textLabelMousedown
-  var click_fn = this.behavior.textLabelClick
-  var drag_behavior = this.behavior.selectableDrag
-  var turn_off_drag = this.behavior.turnOffDrag
+  const mousedown = this.behavior.textLabelMousedown
+  const click = this.behavior.textLabelClick
+  const turnOffDrag = this.behavior.turnOffDrag
+  const drag = this.behavior.selectableDrag
 
   update_selection
     .select('.label')
@@ -894,10 +894,10 @@ function update_text_label (update_selection) {
     .attr('transform', function (d) {
       return 'translate(' + d.x + ',' + d.y + ')'
     })
-    // .on('mousedown', mousedown_fn)
-    // .on('click', click_fn)
-    // .call(turn_off_drag)
-    // .call(drag_behavior)
+    .on('mousedown', mousedown)
+    .on('click', click)
+    .call(turnOffDrag)
+    .call(drag)
 
   this.callback_manager.run('update_text_label', this, update_selection)
 }

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -32,9 +32,6 @@ var utils = require('./utils')
 var dataStyles = require('./dataStyles')
 var CallbackManager = require('./CallbackManager').default
 var d3_format = require('d3-format').format
-var d3_select = require('d3-selection').select
-var d3_mouse = require('d3-selection').mouse
-var d3_touch = require('d3-selection').touch
 
 var Draw = utils.make_class()
 // instance methods
@@ -321,9 +318,10 @@ function update_segment (update_selection, scale, cobra_model,
   const hide_secondary_metabolites = this.settings.get('hide_secondary_metabolites')
   const primary_r = this.settings.get('primary_metabolite_radius')
   const secondary_r = this.settings.get('secondary_metabolite_radius')
-  const object_mouseover_fn = this.behavior.objectMouseover
-  const object_mouseout_fn = this.behavior.objectMouseout
-  const object_touch_fn = this.behavior.objectTouch
+
+  const objectMouseover = this.behavior.reactionObjectMouseover
+  const objectMouseout = this.behavior.reactionObjectMouseout
+
   const get_arrow_size = function (data, should_size) {
     let width = 20
     let height = 13
@@ -416,22 +414,9 @@ function update_segment (update_selection, scale, cobra_model,
         return null
       }
     })
-    // .attr('pointer-events', 'visibleStroke')
-    // .on('mouseover', function (d) {
-    //   const mouseEvent = d3_mouse(this)
-    //   // Add the current mouse position to the segment's datum
-    //   object_mouseover_fn('reaction_object', Object.assign(
-    //     {}, d, {xPos: mouseEvent[0], yPos: mouseEvent[1]}
-    //   ))
-    // })
-    // .on('touchend', function (d) {
-    //   const touchEvent = d3_touch(this.parentNode, 0)
-    //   // Add last touch position to the segment's datum
-    //   object_touch_fn('reaction_object', Object.assign(
-    //     {}, d, {xPos: touchEvent[0], yPos: touchEvent[1]}
-    //   ))
-    // })
-    // .on('mouseout', object_mouseout_fn)
+    .attr('pointer-events', 'visibleStroke')
+    .on('mouseover', objectMouseover)
+    .on('mouseout', objectMouseout)
 
   // new arrowheads
   var arrowheads = update_selection.select('.arrowheads')
@@ -759,9 +744,8 @@ function update_node (update_selection, scale, has_data_on_nodes,
   var labelMouseover = this.behavior.nodeLabelMouseover
   var labelMouseout = this.behavior.nodeLabelMouseout
   var labelTouch = this.behavior.nodeLabelTouch
-  var object_mouseover_fn = this.behavior.objectMouseover
-  var object_mouseout_fn = this.behavior.objectMouseout
-  var object_touch_fn = this.behavior.objectTouch
+  var objectMouseover = this.behavior.nodeObjectMouseover
+  var objectMouseout = this.behavior.nodeObjectMouseout
 
   var mg = update_selection
       .select('.node-circle')
@@ -803,25 +787,8 @@ function update_node (update_selection, scale, has_data_on_nodes,
     .call(drag_behavior)
     .on('mousedown', mousedown_fn)
     .on('click', click_fn)
-    // .on('mouseover', function (d) {
-    //   if (d.node_type === 'metabolite') {
-    //     const mouseEvent = d3_mouse(this.parentNode)
-    //     // Add current mouse position to the node's datum
-    //     object_mouseover_fn('node_object', Object.assign(
-    //       {}, d, {xPos: mouseEvent[0], yPos: mouseEvent[1]}
-    //     ))
-    //   }
-    // })
-    // .on('mouseout', object_mouseout_fn)
-    // .on('touchend', function (d) {
-    //   if (d.node_type === 'metabolite') {
-    //     touchEvent = d3_touch(this.parentNode, 0)
-    //     // Add the touch position to the node's datum
-    //     object_touch_fn('node_object', Object.assign(
-    //       {}, d, {xPos: touchEvent[0], yPos: touchEvent[1]}
-    //     ))
-    //   }
-    // })
+    .on('mouseover', objectMouseover)
+    .on('mouseout', objectMouseout)
 
   // update node label visibility
   var node_label = update_selection

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -173,9 +173,12 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
   const show_gene_reaction_rules = this.settings.get('show_gene_reaction_rules')
   const hide_all_labels = this.settings.get('hide_all_labels')
   const gene_font_size = this.settings.get('gene_font_size')
-  const label_mouseover_fn = this.behavior.labelMouseover
-  const label_mouseout_fn = this.behavior.labelMouseout
-  const label_touch_fn = this.behavior.labelTouch
+  const reactionLabelMouseover = this.behavior.reactionLabelMouseover
+  const reactionLabelMouseout = this.behavior.reactionLabelMouseout
+  const reactionLabelTouch = this.behavior.reactionLabelTouch
+  const geneLabelMouseover = this.behavior.geneLabelMouseover
+  const geneLabelMouseout = this.behavior.geneLabelMouseout
+  const geneLabelTouch = this.behavior.geneLabelTouch
 
   // label location
   update_selection
@@ -199,13 +202,9 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
         }
         return t
       })
-      // .on('mouseover', function (d) {
-      //   label_mouseover_fn('reaction_label', d)
-      // })
-      // .on('mouseout', label_mouseout_fn)
-      // .on('touchend', function (d) {
-      //   label_touch_fn('reaction_label', d)
-      // })
+      .on('mouseover', reactionLabelMouseover)
+      .on('mouseout', reactionLabelMouseout)
+      .on('touchend', reactionLabelTouch)
   }
 
   var add_gene_height = function (y, i) {
@@ -252,11 +251,6 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
   gene_g.append('text')
     .attr('class', 'gene-label')
     .style('font-size', gene_font_size + 'px')
-    // .on('mousedown', label_mousedown_fn)
-    // .on('mouseover', function (d) {
-    //   label_mouseover_fn('gene_label', d)
-    // })
-    // .on('mouseout', label_mouseout_fn)
 
   // update
   var gene_update = gene_g.merge(all_genes_g)
@@ -264,9 +258,12 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
     return 'translate(0, ' + add_gene_height(0, i) + ')'
   })
   // update text
-  gene_update.select('text').text(function (d) {
-    return d['text']
-  })
+  gene_update
+    .select('text')
+    .text(d => d.text)
+    .on('mouseover', geneLabelMouseover)
+    .on('mouseout', geneLabelMouseout)
+    .on('touchend', geneLabelTouch)
 
   // exit
   all_genes_g.exit().remove()
@@ -759,9 +756,9 @@ function update_node (update_selection, scale, has_data_on_nodes,
   var metabolite_data_styles = this.settings.get('metabolite_styles')
   var no_data_style = { color: this.settings.get('metabolite_no_data_color'),
                         size: this.settings.get('metabolite_no_data_size') }
-  var label_mouseover_fn = this.behavior.labelMouseover
-  var label_mouseout_fn = this.behavior.labelMouseout
-  var label_touch_fn = this.behavior.labelTouch
+  var labelMouseover = this.behavior.nodeLabelMouseover
+  var labelMouseout = this.behavior.nodeLabelMouseout
+  var labelTouch = this.behavior.nodeLabelTouch
   var object_mouseover_fn = this.behavior.objectMouseover
   var object_mouseout_fn = this.behavior.objectMouseout
   var object_touch_fn = this.behavior.objectTouch
@@ -846,10 +843,9 @@ function update_node (update_selection, scale, has_data_on_nodes,
       })
       .call(this.behavior.turnOffDrag)
       .call(label_drag_behavior)
-      // .on('mouseover', function (d) {
-      //   label_mouseover_fn('node_label', d)
-      // })
-      // .on('mouseout', label_mouseout_fn)
+      .on('mouseover', labelMouseover)
+      .on('mouseout', labelMouseout)
+      .on('touchend', labelTouch)
   }
 
   this.callback_manager.run('update_node', this, update_selection)

--- a/src/Draw.js
+++ b/src/Draw.js
@@ -173,7 +173,6 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
   const show_gene_reaction_rules = this.settings.get('show_gene_reaction_rules')
   const hide_all_labels = this.settings.get('hide_all_labels')
   const gene_font_size = this.settings.get('gene_font_size')
-  const label_mousedown_fn = this.behavior.labelMousedown
   const label_mouseover_fn = this.behavior.labelMouseover
   const label_mouseout_fn = this.behavior.labelMouseout
   const label_touch_fn = this.behavior.labelTouch
@@ -200,7 +199,6 @@ function update_reaction_label (update_selection, has_data_on_reactions) {
         }
         return t
       })
-      // .on('mousedown', label_mousedown_fn)
       // .on('mouseover', function (d) {
       //   label_mouseover_fn('reaction_label', d)
       // })
@@ -761,7 +759,6 @@ function update_node (update_selection, scale, has_data_on_nodes,
   var metabolite_data_styles = this.settings.get('metabolite_styles')
   var no_data_style = { color: this.settings.get('metabolite_no_data_color'),
                         size: this.settings.get('metabolite_no_data_size') }
-  var label_mousedown_fn = this.behavior.labelMousedown
   var label_mouseover_fn = this.behavior.labelMouseover
   var label_mouseout_fn = this.behavior.labelMouseout
   var label_touch_fn = this.behavior.labelTouch
@@ -847,9 +844,8 @@ function update_node (update_selection, scale, has_data_on_nodes,
           t += ' ' + d.data_string
         return t
       })
-      // .call(this.behavior.turnOffDrag)
-      // .call(label_drag_behavior)
-      // .on('mousedown', label_mousedown_fn)
+      .call(this.behavior.turnOffDrag)
+      .call(label_drag_behavior)
       // .on('mouseover', function (d) {
       //   label_mouseover_fn('node_label', d)
       // })

--- a/src/TooltipContainer.jsx
+++ b/src/TooltipContainer.jsx
@@ -51,6 +51,8 @@ export default class TooltipContainer {
    */
   disableTooltips () {
     this.settings.set('enable_tooltips', false)
+    // draw to update tooltip settings
+    this.map.draw_everything()
     this.hide()
     this.map.set_status(`Tooltips disabled. You can enable them again in the
                          settings menu.`, 3000)
@@ -74,12 +76,7 @@ export default class TooltipContainer {
 
     // connect callbacks to show tooltip
     map.callback_manager.set('show_tooltip.tooltip_container', (type, d) => {
-      // Check if the current element is in the list of tooltips to display
-      const enableTooltips = map.settings.get('enable_tooltips')
-      const newType = type.replace('reaction_', '').replace('node_', '').replace('gene_', '')
-      if (enableTooltips && enableTooltips.includes(newType)) {
-        this.show(type, d)
-      }
+      this.show(type, d)
     })
 
     // callback to hide / delay hide tooltip

--- a/src/TooltipContainer.jsx
+++ b/src/TooltipContainer.jsx
@@ -127,12 +127,8 @@ export default class TooltipContainer {
       const windowScale = this.zoomContainer.windowScale
       const mapSize = this.map !== null ? this.map.get_size() : { width: 1000, height: 1000 }
       const offset = {x: 0, y: 0}
-      const startPosX = (type.replace('reaction_', '').replace('node_', '').replace('gene_', '') === 'object')
-                      ? d.xPos
-                      : d.label_x
-      const startPosY = (type.replace('reaction_', '').replace('node_', '').replace('gene_', '') === 'object')
-                      ? d.yPos
-                      : d.label_y
+      const startPosX = type === 'reaction_object' ? d.xPos : d.label_x
+      const startPosY = type === 'reaction_object' ? d.yPos : d.label_y
       const rightEdge = windowScale * startPosX + windowTranslate.x + tooltipSize.width
       const bottomEdge = windowScale * startPosY + windowTranslate.y + tooltipSize.height
       if (mapSize.width < 500) {

--- a/src/ZoomContainer.js
+++ b/src/ZoomContainer.js
@@ -1,5 +1,3 @@
-/* global requestAnimationFrame */
-
 import utils from './utils'
 import CallbackManager from './CallbackManager'
 
@@ -279,7 +277,7 @@ export default class ZoomContainer {
   _goTo3dFrame () {
     if (!this._requestedFrame) {
       this._requestedFrame = true
-      requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
         this._requestedFrame = false
         const transform = this._3dTransform
         if (transform) {
@@ -320,7 +318,7 @@ export default class ZoomContainer {
   _goToSvgFrame (callback = null) {
     if (!this._requestedFrame || callback) {
       this._requestedFrame = true
-      requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
         this._requestedFrame = false
 
         // reset the 3d transform

--- a/src/ZoomContainer.js
+++ b/src/ZoomContainer.js
@@ -266,6 +266,7 @@ export default class ZoomContainer {
       // redraw the svg
       this._zoomTimeout = _.delay(() => {
         // redraw the svg
+        this._requestedFrame = false
         this._goToSvg(scale, translate)
       }, 100) // between 100 and 600 seems to be usable
     } else { // no 3d transform
@@ -281,13 +282,17 @@ export default class ZoomContainer {
       requestAnimationFrame(() => {
         this._requestedFrame = false
         const transform = this._3dTransform
-        this.css3TransformContainer.style('transform', transform)
-        this.css3TransformContainer.style('-webkit-transform', transform)
-        this.css3TransformContainer.style('transform-origin', '0 0')
-        this.css3TransformContainer.style('-webkit-transform-origin', '0 0')
+        if (transform) {
+          this.css3TransformContainer.style('transform', transform)
+          this.css3TransformContainer.style('-webkit-transform', transform)
+          this.css3TransformContainer.style('transform-origin', '0 0')
+          this.css3TransformContainer.style('-webkit-transform-origin', '0 0')
+        } else {
+          console.warn('No _3dTransform defined')
+        }
       })
     }
-}
+  }
 
   /**
    * Zoom & pan the CSS 3D transform container
@@ -303,10 +308,13 @@ export default class ZoomContainer {
   }
 
   _clear3d () {
-    this.css3TransformContainer.style('transform', null)
-    this.css3TransformContainer.style('-webkit-transform', null)
-    this.css3TransformContainer.style('transform-origin', null)
-    this.css3TransformContainer.style('-webkit-transform-origin', null)
+    if (this._3dTransform) {
+      this._3dTransform = null
+      this.css3TransformContainer.style('transform', null)
+      this.css3TransformContainer.style('-webkit-transform', null)
+      this.css3TransformContainer.style('transform-origin', null)
+      this.css3TransformContainer.style('-webkit-transform-origin', null)
+    }
   }
 
   _goToSvgFrame (callback = null) {
@@ -314,6 +322,10 @@ export default class ZoomContainer {
       this._requestedFrame = true
       requestAnimationFrame(() => {
         this._requestedFrame = false
+
+        // reset the 3d transform
+        this._clear3d()
+
         const scale = this._svgScale
         const translate = this._svgTranslate
         this.zoomedSel
@@ -332,9 +344,6 @@ export default class ZoomContainer {
    * @param {Function} callback - (optional) A callback to run after scaling.
    */
   _goToSvg (scale, translate, callback = null) {
-    // reset the 3d transform
-    this._clear3d()
-
     // redraw the svg
     // save svg location
     this._svgScale = scale

--- a/src/ZoomContainer.js
+++ b/src/ZoomContainer.js
@@ -1,8 +1,10 @@
+/* global requestAnimationFrame */
+
 import utils from './utils'
 import CallbackManager from './CallbackManager'
 
 import _ from 'underscore'
-import { selection as d3Selection, event } from 'd3-selection'
+import { event } from 'd3-selection'
 import {
   zoom as d3Zoom,
   zoomIdentity as d3ZoomIdentity
@@ -105,7 +107,7 @@ export default class ZoomContainer {
       this.zoomedSel.style('cursor', 'grab')
     } else {
       // turn off the hand
-      if (_.contains(['grab', 'grabbing'], this.zoomedSel.style('cursor'))) {
+      if (this.zoomedSel.style('cursor') === 'grab') {
         this.zoomedSel.style('cursor', null)
       }
     }
@@ -142,12 +144,6 @@ export default class ZoomContainer {
     // d3 related to d3 using the global this.document. TODO look into this.
     this._zoomBehavior = d3Zoom()
       .on('start', () => {
-        // Be sure to use an inline style instead of a class to avoid layout
-        if (event.sourceEvent &&
-            event.sourceEvent.type === 'mousedown') {
-          this.zoomedSel.style('cursor', 'grabbing')
-        }
-
         // Prevent default zoom behavior, specifically for mobile pinch zoom
         if (event.sourceEvent !== null) {
           event.sourceEvent.stopPropagation()
@@ -159,12 +155,6 @@ export default class ZoomContainer {
           x: event.transform.x,
           y: event.transform.y
         })
-      })
-      .on('end', () => {
-        if (event.sourceEvent &&
-            event.sourceEvent.type === 'mouseup') {
-          this.zoomedSel.style('cursor', 'grab')
-        }
       })
 
     // Set it up
@@ -332,14 +322,14 @@ export default class ZoomContainer {
   /**
    * Zoom in by the default amount with the default options.
    */
-  zoom_in () {
+  zoom_in () { // eslint-disable-line camelcase
     this.zoomBy(1.5)
   }
 
   /**
    * Zoom out by the default amount with the default options.
    */
-  zoom_out () {
+  zoom_out () { // eslint-disable-line camelcase
     this.zoomBy(0.667)
   }
 
@@ -348,7 +338,7 @@ export default class ZoomContainer {
    * width or height is not defined.
    * @returns {Object} The size coordinates, e.g. { x: 2, y: 3 }.
    */
-  get_size () {
+  get_size () { // eslint-disable-line camelcase
     const {width, height} = this.selection.node().getBoundingClientRect()
     return { width, height }
   }

--- a/src/ZoomContainer.js
+++ b/src/ZoomContainer.js
@@ -102,7 +102,9 @@ export default class ZoomContainer {
     }
 
     if (this._panDragOn) {
-      // turn on the hand
+      // turn on the hand. Performance note: In previous versions of Escher, we
+      // enabled the "grabbing" cursor during pan events. However, this causes a
+      // browser layout and costs about 400ms, so we turned it off.
       this.zoomedSel.style('cursor', 'grab')
     } else {
       // turn off the hand

--- a/src/tests/helpers/d3Body.js
+++ b/src/tests/helpers/d3Body.js
@@ -5,7 +5,7 @@ const { JSDOM } = jsdom
 const d3Select = require('d3-selection').select
 
 // body selection
-const dom = new JSDOM()
+const dom = new JSDOM('', { pretendToBeVisual: true })
 const document = dom.window.document
 const d3Body = d3Select(document).select('body')
 

--- a/src/tests/test_Behavior.js
+++ b/src/tests/test_Behavior.js
@@ -38,11 +38,41 @@ function assertLabelDragAttrsOff (behavior) {
 }
 
 function assertLabelMouseoverAttrsOn (behavior) {
-  assert.isFunction(behavior.labelMouseover)
+  assert.isNotNull(behavior.nodeLabelMouseover)
+  assert.isNotNull(behavior.nodeLabelTouch)
+  assert.isNotNull(behavior.nodeLabelMouseout)
+  assert.isNotNull(behavior.reactionLabelMouseover)
+  assert.isNotNull(behavior.reactionLabelTouch)
+  assert.isNotNull(behavior.reactionLabelMouseout)
+  assert.isNotNull(behavior.geneLabelMouseover)
+  assert.isNotNull(behavior.geneLabelTouch)
+  assert.isNotNull(behavior.geneLabelMouseout)
 }
 
 function assertLabelMouseoverAttrsOff (behavior) {
-  assert.strictEqual(behavior.labelMouseover, behavior.emptyBehavior)
+  assert.isNull(behavior.nodeLabelMouseover)
+  assert.isNull(behavior.nodeLabelTouch)
+  assert.isNull(behavior.nodeLabelMouseout)
+  assert.isNull(behavior.reactionLabelMouseover)
+  assert.isNull(behavior.reactionLabelTouch)
+  assert.isNull(behavior.reactionLabelMouseout)
+  assert.isNull(behavior.geneLabelMouseover)
+  assert.isNull(behavior.geneLabelTouch)
+  assert.isNull(behavior.geneLabelMouseout)
+}
+
+function assertObjectMouseoverAttrsOn (behavior) {
+  assert.isNotNull(behavior.nodeObjectMouseover)
+  assert.isNotNull(behavior.nodeObjectMouseout)
+  assert.isNotNull(behavior.reactionObjectMouseover)
+  assert.isNotNull(behavior.reactionObjectMouseout)
+}
+
+function assertObjectMouseoverAttrsOff (behavior) {
+  assert.isNull(behavior.nodeObjectMouseover)
+  assert.isNull(behavior.nodeObjectMouseout)
+  assert.isNull(behavior.reactionObjectMouseover)
+  assert.isNull(behavior.reactionObjectMouseout)
 }
 
 describe('Behavior', () => {
@@ -53,24 +83,6 @@ describe('Behavior', () => {
 
   it('loads the map', () => {
     assert.strictEqual(behavior.map, map)
-  })
-
-  it('turnEverythingOn', () => {
-    behavior.turnEverythingOff()
-    behavior.turnEverythingOn()
-    assertSelectableClickAttrsOn(behavior)
-    assertSelectableDragAttrsOn(behavior)
-    assertLabelDragAttrsOn(behavior)
-    assertLabelMouseoverAttrsOn(behavior)
-  })
-
-  it('turnEverythingOff', () => {
-    behavior.turnEverythingOn()
-    behavior.turnEverythingOff()
-    assertSelectableClickAttrsOff(behavior)
-    assertSelectableDragAttrsOff(behavior)
-    assertLabelDragAttrsOff(behavior)
-    assertLabelMouseoverAttrsOff(behavior)
   })
 
   it('toggleSelectableClick', () => {
@@ -99,5 +111,12 @@ describe('Behavior', () => {
     assertLabelMouseoverAttrsOn(behavior)
     behavior.toggleLabelMouseover(false)
     assertLabelMouseoverAttrsOff(behavior)
+  })
+
+  it('toggleObjectMouseover', () => {
+    behavior.toggleObjectMouseover(true)
+    assertObjectMouseoverAttrsOn(behavior)
+    behavior.toggleObjectMouseover(false)
+    assertObjectMouseoverAttrsOff(behavior)
   })
 })

--- a/src/tests/test_ZoomContainer.js
+++ b/src/tests/test_ZoomContainer.js
@@ -50,14 +50,14 @@ describe('ZoomContainer', () => {
     assert.strictEqual(zoomTransform.k, 2.0)
     assert.strictEqual(zoomTransform.x, 10.0)
     assert.strictEqual(zoomTransform.y, -20.5)
-    _.defer(() => {
+    _.delay(() => {
       // check node transform attribute
       const transform = d3_transform_catch(zc.zoomedSel.attr('transform'))
       assert.strictEqual(transform.scale, 2.0)
       assert.strictEqual(transform.translate[0], 10.0)
       assert.strictEqual(transform.translate[1], -20.5)
       done()
-    })
+    }, 100)
   })
 
   // TODO waiting on

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,7 +2181,7 @@ d3-transition@1:
     d3-selection "^1.1.0"
     d3-timer "1"
 
-d3-zoom@^1.1.1:
+d3-zoom@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.7.3.tgz#f444effdc9055c38077c4299b4df999eb1d47ccb"
   integrity sha512-xEBSwFx5Z9T3/VrwDkMt+mr0HCzv7XjpGURJ8lWmIC8wxe32L39eWHIasEe/e7Ox8MPU4p1hvH8PKN2olLzIBg==


### PR DESCRIPTION
These changes fix a performance issue with tooltips on objects. When many objects have mouseover event listeners, then pan/zoom performance suffers. Therefore, the tooltip behaviors were optimized so this performance hit only occurs when the tooltips are activated over objects, which is not the default setting.

This PR also implements requestAnimationFrame for more predictable performance with pan/zoom.

Also disabled the grabbing cursor which was causing slowdowns